### PR TITLE
feat: 心拍ゾーン独自計算（%HRRカルボーネン法）を実装しレポートをZ1-Z5に置換

### DIFF
--- a/config/personal.yaml
+++ b/config/personal.yaml
@@ -1,0 +1,11 @@
+# 個人プロファイル（手入力の単一真実）。Fitbit/APIから取得できない属性のみ置く。
+birth_date: 1986-10-25        # age はシステム日付から都度算出（更新不要）
+# height_cm:                  # 将来用
+
+hr_zones:
+  max_hr_override:            # ランプテスト等の実測最大HR。設定時はTanaka推定より優先（空/null=Tanaka）
+  resting_hr:
+    source: heart_rate_csv    # data/fitbit/heart_rate.csv の resting_heart_rate 列
+    window_days: 30           # レポート終了日基準の直近N日中央値で固定
+    fallback: 48              # 窓内にデータが無い場合の代替
+  method: hrr                 # hrr(カルボーネン%HRR) | lthr | pmax（将来拡張）

--- a/docs/adr/001-hr-zone-algorithm.md
+++ b/docs/adr/001-hr-zone-algorithm.md
@@ -1,0 +1,70 @@
+# ADR 001: 心拍ゾーンアルゴリズム
+
+- **Status**: Accepted (2026-05-17)
+- **Deciders**: tsu-nera
+
+---
+
+## Context
+
+Fitbit の Active Zone Minutes (AZM) は「Fat Burn / Cardio / Peak」の3ゾーンで出力される。実データの逆算により、Fitbit の「パーソナライズゾーン」は %最大HR ではなく %HRR（カルボーネン法）であることが判明した。係数は概ね 40/60/85%HRR（39歳 / RHR≈48 / maxHR=181 の条件で ±1bpm 一致）。
+
+bodyレポートの注記「Z2（50-69% HRmax）」は実体（%HRR）と不一致であり、ゾーン定義を統一し正確に表示する必要がある。
+
+---
+
+## Decision
+
+### (1) 最大心拍数
+
+- 推定式: Tanaka式 `208 - 0.7 × age`
+- 220-age は将来精度で劣るが、39歳では両者ともに 181bpm で一致する
+- 観測最大HR の自動上書きは v1 では不採用（上昇途上で境界が動くと時系列比較が破綻する）
+- `config/personal.yaml` の `hr_zones.max_hr_override` に手動で実測値を投入することで上書き可能
+
+### (2) ゾーン定義
+
+- %HRR カルボーネン法を採用
+- 5ゾーン構成、各ゾーンの下限を下記で定義:
+  - Z1（回復）  : 50%HRR
+  - Z2（有酸素）: 60%HRR
+  - Z3（テンポ）: 70%HRR
+  - Z4（閾値）  : 80%HRR
+  - Z5（VO2max）: 90%HRR
+- 将来的に `method: lthr`（Friel法）への切替が可能な構造とする
+
+### (3) 安静時心拍数
+
+- `data/fitbit/heart_rate.csv` の `resting_heart_rate` 列を使用
+- レポート終了日を基準とした直近 30日の中央値（期間内固定）
+- レポート長に依存しない安定した値となる
+- ウィンドウ内にデータが無い場合は `fallback` 値（デフォルト 48bpm）を使用
+
+### (4) 設定ファイル
+
+- `config/personal.yaml` を汎用個人プロファイルとして導入
+- `birth_date` を単一真実とし、`age` はシステム日付から自動算出（更新不要）
+- `hr_zones` 配下にゾーン関連設定をネスト
+
+### (5) レポート表示
+
+- レポートのゾーン表示を Z1-Z5 に完全置換
+- 旧 AZM 表示（fat_burn / cardio / peak）は削除
+- Fitbit AZM 取得パイプライン（fetch/parse/active_zone_minutes.csv）は温存
+
+### (6) Fitbit AZM パイプラインの温存
+
+- `src/lib/clients/fitbit_api.py` の `parse_active_zone_minutes`
+- `src/lib/fitbit_fetcher.py` の active_zone_minutes 定義
+- `data/fitbit/active_zone_minutes.csv`
+
+上記は一切変更しない。
+
+---
+
+## Consequences
+
+- Fitbit の公式ゾーン値とは別系統の独自ゾーン計算になる
+- Fitbit vs 独自の比較表・差分分析・ブログ分析は別 issue で対応（`active_zone_minutes.csv` 生データを入力として使用）
+- レポートのゾーン境界は安静時HRの長期ドリフトに月単位で追従する
+- LTHR 移行は閾値テスト実測後の後続作業となる

--- a/scripts/generate_body_report_daily.py
+++ b/scripts/generate_body_report_daily.py
@@ -23,6 +23,7 @@ sys.path.insert(0, str(project_root / 'src'))
 from lib.analytics import sleep, hrv, body, nutrition, activity, training
 from lib.analytics import hr_zones
 from lib.utils.report_args import add_common_report_args, parse_period_args, determine_output_dir, filter_dataframe_by_period
+from lib.utils.data_loader import determine_target_period
 
 BASE_DIR = project_root
 DATA_CSV = BASE_DIR / 'data/healthplanet_innerscan.csv'
@@ -289,7 +290,8 @@ def calc_strength_stats_for_period(start_date, end_date):
 
 
 def prepare_report_data(df, stats, sleep_stats=None, activity_stats=None,
-                        hrv_stats=None, nutrition_stats=None, eat_stats=None):
+                        hrv_stats=None, nutrition_stats=None, eat_stats=None,
+                        target_end=None):
     """
     テンプレートに渡すレポートコンテキストを準備
 
@@ -309,6 +311,9 @@ def prepare_report_data(df, stats, sleep_stats=None, activity_stats=None,
         栄養統計
     eat_stats : dict, optional
         EAT統計
+    target_end : pd.Timestamp, optional
+        レポート引数の終了日（今日など）。hr_zones の RHR 計算基準日として使う。
+        healthplanet 最終測定日（= dates.max()）でなく必ずこちらを渡すこと。
 
     Returns
     -------
@@ -375,8 +380,8 @@ def prepare_report_data(df, stats, sleep_stats=None, activity_stats=None,
     strength_data = None
     if activity_stats:
         training_data = {}
-        # 有酸素運動データの準備
-        aerobic_data = _prepare_aerobic_data(start_date, end_date, activity_stats)
+        # 有酸素運動データの準備（ref_date=target_end で RHR 基準日を統一）
+        aerobic_data = _prepare_aerobic_data(start_date, end_date, activity_stats, ref_date=target_end)
     cycling_stats = calc_cycling_stats_for_period(start_date, end_date)
     strength_stats = calc_strength_stats_for_period(start_date, end_date)
     cycling_data = cycling_stats['daily'] if cycling_stats else None
@@ -429,8 +434,22 @@ def prepare_report_data(df, stats, sleep_stats=None, activity_stats=None,
     return context
 
 
-def _prepare_aerobic_data(start_date, end_date, activity_stats):
-    """有酸素運動データを準備（hr_zones ベースのゾーン分類）"""
+def _prepare_aerobic_data(start_date, end_date, activity_stats, ref_date=None):
+    """有酸素運動データを準備（hr_zones ベースのゾーン分類）
+
+    Parameters
+    ----------
+    start_date : pd.Timestamp
+        表示期間開始日（healthplanet 測定日由来）
+    end_date : pd.Timestamp
+        表示期間終了日（healthplanet 測定日由来）
+    activity_stats : dict
+        アクティビティ統計
+    ref_date : datetime.date, optional
+        RHR ウィンドウ計算の基準日。未指定時は end_date を使用するが、
+        必ず target_end（レポート引数の終了日=今日など）を渡すこと。
+        mind と境界を一致させる設計要件のため。
+    """
     import datetime as _dt
 
     # hr_zones 算出
@@ -441,7 +460,11 @@ def _prepare_aerobic_data(start_date, end_date, activity_stats):
     fallback = resting_hr_cfg.get('fallback', 48)
     method = hr_zones_cfg.get('method', 'hrr')
 
-    end_dt = end_date.date() if hasattr(end_date, 'date') else end_date
+    # ref_date: RHR ウィンドウ計算の基準日は必ず target_end を使う（healthplanet 最終日でなく）
+    if ref_date is not None:
+        end_dt = ref_date.date() if hasattr(ref_date, 'date') else ref_date
+    else:
+        end_dt = end_date.date() if hasattr(end_date, 'date') else end_date
 
     df_hr_daily_raw = None
     if HEART_RATE_MASTER_CSV.exists():
@@ -610,7 +633,7 @@ def _prepare_recovery_data(start_date, end_date, df_sleep_filtered, hrv_stats):
     return recovery_data
 
 
-def generate_report(output_dir, df, stats, sleep_stats=None, activity_stats=None, hrv_stats=None, nutrition_stats=None, eat_stats=None):
+def generate_report(output_dir, df, stats, sleep_stats=None, activity_stats=None, hrv_stats=None, nutrition_stats=None, eat_stats=None, target_end=None):
     """マークダウンレポートを生成（Jinja2テンプレート版）"""
     from lib.templates.renderer import BodyReportRenderer
 
@@ -618,7 +641,8 @@ def generate_report(output_dir, df, stats, sleep_stats=None, activity_stats=None
 
     # データ準備
     context = prepare_report_data(df, stats, sleep_stats, activity_stats,
-                                  hrv_stats, nutrition_stats, eat_stats)
+                                  hrv_stats, nutrition_stats, eat_stats,
+                                  target_end=target_end)
 
     # テンプレートレンダリング
     renderer = BodyReportRenderer()
@@ -640,6 +664,12 @@ def main():
 
     # Parse period arguments
     week, month, year = parse_period_args(args)
+
+    # target_end: hr_zones の RHR 計算基準日（mind と統一するため明示的に取得）
+    try:
+        _, target_end = determine_target_period(week, month, year, args.days)
+    except ValueError:
+        target_end = None
 
     # Load data
     df = pd.read_csv(DATA_CSV, index_col='date', parse_dates=True)
@@ -701,7 +731,7 @@ def main():
     plot_main_chart(df, img_dir / 'trend.png')
 
     # Generate report
-    generate_report(output_dir, df, stats, sleep_stats, activity_stats, hrv_stats, nutrition_stats, eat_stats)
+    generate_report(output_dir, df, stats, sleep_stats, activity_stats, hrv_stats, nutrition_stats, eat_stats, target_end=target_end)
 
     return 0
 

--- a/scripts/generate_body_report_daily.py
+++ b/scripts/generate_body_report_daily.py
@@ -21,6 +21,7 @@ project_root = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(project_root / 'src'))
 
 from lib.analytics import sleep, hrv, body, nutrition, activity, training
+from lib.analytics import hr_zones
 from lib.utils.report_args import add_common_report_args, parse_period_args, determine_output_dir, filter_dataframe_by_period
 
 BASE_DIR = project_root
@@ -30,8 +31,8 @@ ACTIVITY_MASTER_CSV = BASE_DIR / 'data/fitbit/activity.csv'
 ACTIVITY_LOGS_CSV = BASE_DIR / 'data/fitbit/activity_logs.csv'
 HRV_MASTER_CSV = BASE_DIR / 'data/fitbit/hrv.csv'
 HEART_RATE_MASTER_CSV = BASE_DIR / 'data/fitbit/heart_rate.csv'
+HEART_RATE_INTRADAY_CSV = BASE_DIR / 'data/fitbit/heart_rate_intraday.csv'
 NUTRITION_MASTER_CSV = BASE_DIR / 'data/fitbit/nutrition.csv'
-ACTIVE_ZONE_CSV = BASE_DIR / 'data/fitbit/active_zone_minutes.csv'
 CARDIO_SCORE_CSV = BASE_DIR / 'data/fitbit/cardio_score.csv'
 
 
@@ -394,6 +395,9 @@ def prepare_report_data(df, stats, sleep_stats=None, activity_stats=None,
     # 回復セクションのデータ準備
     recovery_data = _prepare_recovery_data(start_date, end_date, df_sleep_filtered, hrv_stats)
 
+    # hr_zone_meta を取得（_prepare_aerobic_data 実行後にセットされる）
+    hr_zone_meta = getattr(_prepare_aerobic_data, 'hr_zone_meta', None)
+
     # コンテキスト構築
     context = {
         'report_title': 'フィットネスデイリーレポート',
@@ -411,6 +415,7 @@ def prepare_report_data(df, stats, sleep_stats=None, activity_stats=None,
         'nutrition_data': nutrition_section_data,
         'calorie_analysis_data': calorie_analysis_data,
         'recovery_data': recovery_data,
+        'hr_zone_meta': hr_zone_meta,
         'detail_data': {
             'trend_image': 'img/trend.png',
             'daily_table': body.format_daily_table(
@@ -425,13 +430,36 @@ def prepare_report_data(df, stats, sleep_stats=None, activity_stats=None,
 
 
 def _prepare_aerobic_data(start_date, end_date, activity_stats):
-    """有酸素運動データを準備"""
-    # Active ZoneとVO2 Maxデータを読み込み
-    df_active_zone = None
-    if ACTIVE_ZONE_CSV.exists():
-        df_active_zone = pd.read_csv(ACTIVE_ZONE_CSV)
-        df_active_zone['date'] = pd.to_datetime(df_active_zone['date'])
+    """有酸素運動データを準備（hr_zones ベースのゾーン分類）"""
+    import datetime as _dt
 
+    # hr_zones 算出
+    personal_cfg = hr_zones.load_personal_config()
+    hr_zones_cfg = personal_cfg.get('hr_zones', {})
+    resting_hr_cfg = hr_zones_cfg.get('resting_hr', {})
+    window_days = resting_hr_cfg.get('window_days', 30)
+    fallback = resting_hr_cfg.get('fallback', 48)
+    method = hr_zones_cfg.get('method', 'hrr')
+
+    end_dt = end_date.date() if hasattr(end_date, 'date') else end_date
+
+    df_hr_daily_raw = None
+    if HEART_RATE_MASTER_CSV.exists():
+        df_hr_daily_raw = pd.read_csv(HEART_RATE_MASTER_CSV)
+
+    df_hr_intraday = None
+    if HEART_RATE_INTRADAY_CSV.exists():
+        df_hr_intraday = pd.read_csv(HEART_RATE_INTRADAY_CSV, index_col='datetime', parse_dates=True)
+
+    max_hr = hr_zones.calc_max_hr(personal_cfg, end_dt)
+    resting_hr = hr_zones.calc_resting_hr(df_hr_daily_raw, end_dt, window_days, fallback) if df_hr_daily_raw is not None else float(fallback)
+    bounds = hr_zones.compute_zone_bounds(max_hr, resting_hr, method)
+
+    df_zone = None
+    if df_hr_intraday is not None:
+        df_zone = hr_zones.calc_daily_zone_minutes(df_hr_intraday, bounds)
+
+    # VO2 Max データ
     df_vo2max = None
     if CARDIO_SCORE_CSV.exists():
         df_vo2max = pd.read_csv(CARDIO_SCORE_CSV)
@@ -451,24 +479,27 @@ def _prepare_aerobic_data(start_date, end_date, activity_stats):
         else:
             row['steps'] = None
 
-        # Active Zoneデータ
-        if df_active_zone is not None:
-            zone_day = df_active_zone[df_active_zone['date'] == date]
-            if len(zone_day) > 0:
-                row['active_zone'] = zone_day['activeZoneMinutes'].iloc[0]
-                row['fat_burn'] = zone_day['fatBurnActiveZoneMinutes'].iloc[0] if pd.notna(zone_day['fatBurnActiveZoneMinutes'].iloc[0]) else None
-                row['cardio'] = zone_day['cardioActiveZoneMinutes'].iloc[0] if pd.notna(zone_day['cardioActiveZoneMinutes'].iloc[0]) else None
-                row['peak'] = zone_day['peakActiveZoneMinutes'].iloc[0] if pd.notna(zone_day['peakActiveZoneMinutes'].iloc[0]) else None
-            else:
-                row['active_zone'] = None
-                row['fat_burn'] = None
-                row['cardio'] = None
-                row['peak'] = None
+        # 心拍ゾーンデータ
+        if df_zone is not None and date in df_zone.index:
+            val = pd.to_numeric(df_zone.loc[date, 'z1_min'], errors='coerce')
+            row['z1_min'] = int(val) if pd.notna(val) else None
+            val = pd.to_numeric(df_zone.loc[date, 'z2_min'], errors='coerce')
+            row['z2_min'] = int(val) if pd.notna(val) else None
+            val = pd.to_numeric(df_zone.loc[date, 'z3_min'], errors='coerce')
+            row['z3_min'] = int(val) if pd.notna(val) else None
+            val = pd.to_numeric(df_zone.loc[date, 'z4_min'], errors='coerce')
+            row['z4_min'] = int(val) if pd.notna(val) else None
+            val = pd.to_numeric(df_zone.loc[date, 'z5_min'], errors='coerce')
+            row['z5_min'] = int(val) if pd.notna(val) else None
+            val = pd.to_numeric(df_zone.loc[date, 'total_zone_min'], errors='coerce')
+            row['total_zone_min'] = int(val) if pd.notna(val) else None
         else:
-            row['active_zone'] = None
-            row['fat_burn'] = None
-            row['cardio'] = None
-            row['peak'] = None
+            row['z1_min'] = None
+            row['z2_min'] = None
+            row['z3_min'] = None
+            row['z4_min'] = None
+            row['z5_min'] = None
+            row['total_zone_min'] = None
 
         # VO2 Maxデータ
         if df_vo2max is not None:
@@ -481,6 +512,21 @@ def _prepare_aerobic_data(start_date, end_date, activity_stats):
             row['vo2max'] = None
 
         aerobic_data.append(row)
+
+    # meta を返すためにグローバル変数に格納（コンテキストで参照）
+    birth_date = personal_cfg.get('birth_date')
+    if isinstance(birth_date, str):
+        birth_date = _dt.date.fromisoformat(birth_date)
+    age = hr_zones.calc_age(birth_date, end_dt)
+    _prepare_aerobic_data.hr_zone_meta = {
+        'max_hr': max_hr,
+        'resting_hr': resting_hr,
+        'age': age,
+        'method': method,
+        'hrr': float(max_hr - resting_hr),
+        'bounds': bounds,
+        'window_days': window_days,
+    }
 
     return aerobic_data
 

--- a/scripts/generate_mind_report_daily.py
+++ b/scripts/generate_mind_report_daily.py
@@ -22,12 +22,14 @@ project_root = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(project_root / 'src'))
 
 from lib.analytics import mind
+from lib.analytics import hr_zones
 from lib.utils.report_args import add_common_report_args, parse_period_args, determine_output_dir
 from lib.utils.data_loader import load_csv_with_baseline_window, determine_target_period
 
 BASE_DIR = project_root
 HRV_CSV = BASE_DIR / 'data/fitbit/hrv.csv'
 HEART_RATE_CSV = BASE_DIR / 'data/fitbit/heart_rate.csv'
+HEART_RATE_INTRADAY_CSV = BASE_DIR / 'data/fitbit/heart_rate_intraday.csv'
 SLEEP_CSV = BASE_DIR / 'data/fitbit/sleep.csv'
 SLEEP_LEVELS_CSV = BASE_DIR / 'data/fitbit/sleep_levels.csv'
 BREATHING_RATE_CSV = BASE_DIR / 'data/fitbit/breathing_rate.csv'
@@ -35,7 +37,6 @@ SPO2_CSV = BASE_DIR / 'data/fitbit/spo2.csv'
 CARDIO_SCORE_CSV = BASE_DIR / 'data/fitbit/cardio_score.csv'
 TEMPERATURE_SKIN_CSV = BASE_DIR / 'data/fitbit/temperature_skin.csv'
 ACTIVITY_CSV = BASE_DIR / 'data/fitbit/activity.csv'
-ACTIVE_ZONE_MINUTES_CSV = BASE_DIR / 'data/fitbit/active_zone_minutes.csv'
 ACTIVITY_LOGS_CSV = BASE_DIR / 'data/fitbit/activity_logs.csv'
 
 
@@ -447,7 +448,7 @@ def plot_comprehensive_trend(responsiveness_data, sleep_patterns_data, save_path
     plt.close()
 
 
-def prepare_mind_report_data(responsiveness_daily, exertion_balance_daily, sleep_patterns_daily, alerts, period_str, days):
+def prepare_mind_report_data(responsiveness_daily, exertion_balance_daily, sleep_patterns_daily, alerts, period_str, days, hr_zone_meta=None):
     """
     3軸メンタルレポート用のコンテキストデータを準備
 
@@ -465,6 +466,8 @@ def prepare_mind_report_data(responsiveness_daily, exertion_balance_daily, sleep
         期間文字列
     days : int
         日数
+    hr_zone_meta : dict, optional
+        心拍ゾーンメタ情報
 
     Returns
     -------
@@ -496,6 +499,9 @@ def prepare_mind_report_data(responsiveness_daily, exertion_balance_daily, sleep
         # 免疫ストレススコア推移表（フォーマット済みテキスト）
         'immune_stress_table': immune_stress_table,
 
+        # 心拍ゾーンメタ情報
+        'hr_zone_meta': hr_zone_meta,
+
         # チャート
         'charts': {
             'hrv_rhr': 'img/hrv_rhr.png',
@@ -507,7 +513,7 @@ def prepare_mind_report_data(responsiveness_daily, exertion_balance_daily, sleep
     return context
 
 
-def generate_report(output_dir, responsiveness_daily, exertion_balance_daily, sleep_patterns_daily, alerts, period_str, days):
+def generate_report(output_dir, responsiveness_daily, exertion_balance_daily, sleep_patterns_daily, alerts, period_str, days, hr_zone_meta=None):
     """
     マークダウンレポートを生成（Jinja2テンプレート版）
 
@@ -519,11 +525,12 @@ def generate_report(output_dir, responsiveness_daily, exertion_balance_daily, sl
         alerts: アラートリスト
         period_str: 期間文字列
         days: 日数
+        hr_zone_meta: 心拍ゾーンメタ情報
     """
     from lib.templates.renderer import MindReportRenderer
 
     # コンテキストデータ準備
-    context = prepare_mind_report_data(responsiveness_daily, exertion_balance_daily, sleep_patterns_daily, alerts, period_str, days)
+    context = prepare_mind_report_data(responsiveness_daily, exertion_balance_daily, sleep_patterns_daily, alerts, period_str, days, hr_zone_meta=hr_zone_meta)
 
     # テンプレートレンダリング
     renderer = MindReportRenderer()
@@ -613,13 +620,6 @@ def main():
     if ACTIVITY_CSV.exists():
         data['activity'] = load_csv_with_baseline_window(
             ACTIVITY_CSV, target_start, target_end,
-            baseline_window=0
-        )
-
-    # アクティブゾーン分（ベースライン不要）
-    if ACTIVE_ZONE_MINUTES_CSV.exists():
-        data['active_zone_minutes'] = load_csv_with_baseline_window(
-            ACTIVE_ZONE_MINUTES_CSV, target_start, target_end,
             baseline_window=0
         )
 
@@ -725,11 +725,44 @@ def main():
         df_spo2=data.get('spo2')
     )
 
+    # 心拍ゾーン算出（hr_zones ライブラリ使用）
+    personal_cfg = hr_zones.load_personal_config()
+    df_hr_intraday = pd.read_csv(HEART_RATE_INTRADAY_CSV, index_col='datetime', parse_dates=True) if HEART_RATE_INTRADAY_CSV.exists() else None
+    df_hr_daily_raw = pd.read_csv(HEART_RATE_CSV) if HEART_RATE_CSV.exists() else None
+    hr_zone_meta = None
+    df_zone = None
+    if df_hr_intraday is not None and df_hr_daily_raw is not None:
+        hr_zones_cfg = personal_cfg.get('hr_zones', {})
+        resting_hr_cfg = hr_zones_cfg.get('resting_hr', {})
+        window_days = resting_hr_cfg.get('window_days', 30)
+        fallback = resting_hr_cfg.get('fallback', 48)
+        method = hr_zones_cfg.get('method', 'hrr')
+        import datetime as dt
+        end_dt = target_end.date() if hasattr(target_end, 'date') else target_end
+        max_hr = hr_zones.calc_max_hr(personal_cfg, end_dt)
+        resting_hr = hr_zones.calc_resting_hr(df_hr_daily_raw, end_dt, window_days, fallback)
+        bounds = hr_zones.compute_zone_bounds(max_hr, resting_hr, method)
+        df_zone = hr_zones.calc_daily_zone_minutes(df_hr_intraday, bounds)
+        import datetime as _dt
+        birth_date = personal_cfg.get('birth_date')
+        if isinstance(birth_date, str):
+            birth_date = _dt.date.fromisoformat(birth_date)
+        age = hr_zones.calc_age(birth_date, end_dt)
+        hr_zone_meta = {
+            'max_hr': max_hr,
+            'resting_hr': resting_hr,
+            'age': age,
+            'method': method,
+            'hrr': float(max_hr - resting_hr),
+            'bounds': bounds,
+            'window_days': window_days,
+        }
+
     exertion_balance_daily = mind.prepare_exertion_balance_daily_data(
         start_date=target_start,
         end_date=target_end,
         df_activity=data.get('activity'),
-        df_azm=data.get('active_zone_minutes')
+        df_zone=df_zone
     )
 
     sleep_patterns_daily = mind.prepare_sleep_patterns_daily_data(
@@ -768,7 +801,7 @@ def main():
     # レポート生成
     print()
     print('レポート生成中...')
-    generate_report(output_dir, responsiveness_daily, exertion_balance_daily, sleep_patterns_daily, alerts, period_str, len(responsiveness_daily))
+    generate_report(output_dir, responsiveness_daily, exertion_balance_daily, sleep_patterns_daily, alerts, period_str, len(responsiveness_daily), hr_zone_meta=hr_zone_meta)
 
     print()
     print('='*60)

--- a/src/lib/analytics/hr_zones.py
+++ b/src/lib/analytics/hr_zones.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python
+# coding: utf-8
+"""
+心拍ゾーン計算ライブラリ
+
+%HRRカルボーネン法による心拍ゾーン算出を提供。
+"""
+
+import datetime
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+# ゾーン定義
+ZONE_NAMES = ['Z1', 'Z2', 'Z3', 'Z4', 'Z5']
+ZONE_LABELS = {'Z1': '回復', 'Z2': '有酸素', 'Z3': 'テンポ', 'Z4': '閾値', 'Z5': 'VO2max'}
+ZONE_THRESHOLDS = {'hrr': {'Z1': 0.50, 'Z2': 0.60, 'Z3': 0.70, 'Z4': 0.80, 'Z5': 0.90}}
+
+
+def load_personal_config(config_path=None):
+    """個人プロファイルをロードする。
+
+    Parameters
+    ----------
+    config_path : str or Path, optional
+        personal.yaml のパス。未指定時はリポジトリルートの config/personal.yaml を使用。
+
+    Returns
+    -------
+    dict
+        personal.yaml の内容。
+
+    Raises
+    ------
+    FileNotFoundError
+        config/personal.yaml が存在しない場合。
+    """
+    if config_path is None:
+        # __file__ から repo ルートを特定
+        p = Path(__file__).resolve()
+        repo_root = None
+        for parent in p.parents:
+            if parent.name == 'dailybuild' or (parent / 'config').is_dir():
+                repo_root = parent
+                break
+        if repo_root is None:
+            raise FileNotFoundError("リポジトリルートが見つかりません。config/personal.yaml のパスを明示してください。")
+        config_path = repo_root / 'config' / 'personal.yaml'
+    else:
+        config_path = Path(config_path)
+
+    if not config_path.exists():
+        raise FileNotFoundError(f"personal.yaml が見つかりません: {config_path}")
+
+    with open(config_path, 'r', encoding='utf-8') as f:
+        return yaml.safe_load(f)
+
+
+def calc_age(birth_date, ref_date):
+    """年齢を算出する。
+
+    Parameters
+    ----------
+    birth_date : datetime.date
+        生年月日。
+    ref_date : datetime.date
+        基準日（通常はレポート終了日）。
+
+    Returns
+    -------
+    int
+        年齢（歳）。
+    """
+    age = ref_date.year - birth_date.year
+    # 誕生日未到来分を引く
+    if (ref_date.month, ref_date.day) < (birth_date.month, birth_date.day):
+        age -= 1
+    return age
+
+
+def calc_max_hr(personal_cfg, ref_date):
+    """最大心拍数を算出する。
+
+    Parameters
+    ----------
+    personal_cfg : dict
+        load_personal_config() の戻り値。
+    ref_date : datetime.date
+        基準日。
+
+    Returns
+    -------
+    int
+        最大心拍数 (bpm)。
+    """
+    hr_zones_cfg = personal_cfg.get('hr_zones', {})
+    override = hr_zones_cfg.get('max_hr_override')
+    if override is not None and override != '':
+        return int(override)
+
+    # Tanaka 推定式: 208 - 0.7 × age
+    birth_date = personal_cfg.get('birth_date')
+    if isinstance(birth_date, str):
+        birth_date = datetime.date.fromisoformat(birth_date)
+    age = calc_age(birth_date, ref_date)
+    return round(208 - 0.7 * age)
+
+
+def calc_resting_hr(df_hr_daily, ref_date, window_days, fallback):
+    """安静時心拍数を算出する。
+
+    直近 window_days 日間の中央値を返す。
+
+    Parameters
+    ----------
+    df_hr_daily : pd.DataFrame
+        heart_rate.csv を読んだ DataFrame。列: date, resting_heart_rate。
+        未ソート・欠損あり前提。
+    ref_date : datetime.date
+        ウィンドウの終了日（基準日）。
+    window_days : int
+        ウィンドウサイズ（日数）。
+    fallback : float or int
+        ウィンドウ内にデータが無い場合の代替値。
+
+    Returns
+    -------
+    float
+        安静時心拍数 (bpm)。
+    """
+    df = df_hr_daily.copy()
+    df['date'] = pd.to_datetime(df['date'])
+
+    ref_ts = pd.Timestamp(ref_date)
+    window_start = ref_ts - pd.Timedelta(days=window_days - 1)
+
+    mask = (df['date'] >= window_start) & (df['date'] <= ref_ts)
+    df_window = df[mask]
+
+    rhr_series = pd.to_numeric(df_window['resting_heart_rate'], errors='coerce').dropna()
+
+    if len(rhr_series) == 0:
+        return float(fallback)
+
+    return float(rhr_series.median())
+
+
+def compute_zone_bounds(max_hr, resting_hr, method='hrr'):
+    """心拍ゾーンの下限境界を算出する。
+
+    Parameters
+    ----------
+    max_hr : int
+        最大心拍数 (bpm)。
+    resting_hr : float
+        安静時心拍数 (bpm)。
+    method : str
+        ゾーン算出方法（現在は 'hrr' のみ対応）。
+
+    Returns
+    -------
+    dict
+        各ゾーンの下限値 {'Z1': float, 'Z2': float, ..., 'Z5': float}。
+    """
+    thresholds = ZONE_THRESHOLDS[method]
+    hrr = max_hr - resting_hr
+
+    bounds = {}
+    for zone in ZONE_NAMES:
+        k = thresholds[zone]
+        bounds[zone] = resting_hr + k * hrr
+
+    # 下限が単調増加であることを検証
+    prev = None
+    for zone in ZONE_NAMES:
+        if prev is not None:
+            assert bounds[zone] > prev, f"ゾーン境界が単調増加ではありません: {bounds}"
+        prev = bounds[zone]
+
+    return bounds
+
+
+def classify_hr(bpm, bounds):
+    """心拍数をゾーンに分類する。
+
+    Parameters
+    ----------
+    bpm : float or int
+        心拍数 (bpm)。
+    bounds : dict
+        compute_zone_bounds() の戻り値。
+
+    Returns
+    -------
+    str or None
+        ゾーン名 ('Z1'〜'Z5')。Z1未満の場合は None。
+    """
+    if bpm < bounds['Z1']:
+        return None
+
+    # 最上位ゾーンから順に判定
+    for zone in reversed(ZONE_NAMES):
+        if bpm >= bounds[zone]:
+            return zone
+
+    return None
+
+
+def calc_daily_zone_minutes(df_hr_intraday, bounds):
+    """1分データから日別ゾーン分数を集計する。
+
+    Parameters
+    ----------
+    df_hr_intraday : pd.DataFrame
+        index=datetime (parse_dates)、列 heart_rate。1行=1分。
+    bounds : dict
+        compute_zone_bounds() の戻り値。
+
+    Returns
+    -------
+    pd.DataFrame
+        index=正規化日付(pd.Timestamp)、列 z1_min, z2_min, z3_min, z4_min, z5_min (int)、
+        total_zone_min (int)。
+    """
+    df = df_hr_intraday.copy()
+    df['bpm'] = pd.to_numeric(df['heart_rate'], errors='coerce')
+    df['zone'] = df['bpm'].apply(lambda x: classify_hr(x, bounds) if pd.notna(x) else None)
+    df['date'] = df.index.normalize()
+
+    result_rows = []
+    for date, group in df.groupby('date'):
+        row = {'date': date}
+        for z in ZONE_NAMES:
+            col = z.lower() + '_min'
+            row[col] = int((group['zone'] == z).sum())
+        row['total_zone_min'] = sum(row[z.lower() + '_min'] for z in ZONE_NAMES)
+        result_rows.append(row)
+
+    if not result_rows:
+        return pd.DataFrame(columns=['z1_min', 'z2_min', 'z3_min', 'z4_min', 'z5_min', 'total_zone_min'])
+
+    df_result = pd.DataFrame(result_rows).set_index('date')
+    return df_result
+
+
+def prepare_hr_zone_daily_data(start_date, end_date, df_hr_intraday, df_hr_daily, personal_cfg):
+    """心拍ゾーン日別データを準備する。
+
+    Parameters
+    ----------
+    start_date : datetime.date or str
+        レポート開始日。
+    end_date : datetime.date or str
+        レポート終了日（ref_date として使用）。
+    df_hr_intraday : pd.DataFrame
+        heart_rate_intraday.csv を読んだ DataFrame（index=datetime）。
+    df_hr_daily : pd.DataFrame
+        heart_rate.csv を読んだ DataFrame（列: date, resting_heart_rate）。
+    personal_cfg : dict
+        load_personal_config() の戻り値。
+
+    Returns
+    -------
+    tuple[list[dict], dict]
+        (daily_list, meta)
+        daily_list: 各日の dict リスト
+        meta: max_hr, resting_hr, age, method, hrr, bounds, window_days
+    """
+    if isinstance(end_date, str):
+        end_date = datetime.date.fromisoformat(end_date)
+    if isinstance(start_date, str):
+        start_date = datetime.date.fromisoformat(start_date)
+
+    hr_zones_cfg = personal_cfg.get('hr_zones', {})
+    resting_hr_cfg = hr_zones_cfg.get('resting_hr', {})
+    window_days = resting_hr_cfg.get('window_days', 30)
+    fallback = resting_hr_cfg.get('fallback', 48)
+    method = hr_zones_cfg.get('method', 'hrr')
+
+    birth_date = personal_cfg.get('birth_date')
+    if isinstance(birth_date, str):
+        birth_date = datetime.date.fromisoformat(birth_date)
+
+    # end_date を ref_date として算出（レポート1回=1組の境界）
+    max_hr = calc_max_hr(personal_cfg, end_date)
+    resting_hr = calc_resting_hr(df_hr_daily, end_date, window_days, fallback)
+    age = calc_age(birth_date, end_date)
+    bounds = compute_zone_bounds(max_hr, resting_hr, method)
+    hrr = float(max_hr - resting_hr)
+
+    # 日別ゾーン集計
+    df_zone = calc_daily_zone_minutes(df_hr_intraday, bounds)
+
+    # 全日付を列挙
+    all_dates = pd.date_range(start=start_date, end=end_date, freq='D')
+    daily_list = []
+
+    for date in all_dates:
+        row = {'date': date}
+        if date in df_zone.index:
+            row['z1_min'] = int(df_zone.loc[date, 'z1_min'])
+            row['z2_min'] = int(df_zone.loc[date, 'z2_min'])
+            row['z3_min'] = int(df_zone.loc[date, 'z3_min'])
+            row['z4_min'] = int(df_zone.loc[date, 'z4_min'])
+            row['z5_min'] = int(df_zone.loc[date, 'z5_min'])
+            row['total_zone_min'] = int(df_zone.loc[date, 'total_zone_min'])
+        else:
+            row['z1_min'] = None
+            row['z2_min'] = None
+            row['z3_min'] = None
+            row['z4_min'] = None
+            row['z5_min'] = None
+            row['total_zone_min'] = None
+        daily_list.append(row)
+
+    meta = {
+        'max_hr': max_hr,
+        'resting_hr': resting_hr,
+        'age': age,
+        'method': method,
+        'hrr': hrr,
+        'bounds': bounds,
+        'window_days': window_days,
+    }
+
+    return daily_list, meta
+
+
+if __name__ == '__main__':
+    import sys
+
+    repo_root = Path(__file__).resolve().parents[3]
+    print(f"Repo root: {repo_root}")
+
+    # データロード
+    hr_intraday_path = repo_root / 'data' / 'fitbit' / 'heart_rate_intraday.csv'
+    hr_daily_path = repo_root / 'data' / 'fitbit' / 'heart_rate.csv'
+
+    df_hr_intraday = pd.read_csv(hr_intraday_path, index_col='datetime', parse_dates=True)
+    df_hr_daily = pd.read_csv(hr_daily_path)
+
+    personal_cfg = load_personal_config()
+    print(f"personal_cfg loaded: birth_date={personal_cfg.get('birth_date')}")
+
+    # 直近7日
+    today = datetime.date.today()
+    end_date = today
+    start_date = today - datetime.timedelta(days=6)
+
+    print(f"Period: {start_date} ~ {end_date}")
+
+    daily_list, meta = prepare_hr_zone_daily_data(start_date, end_date, df_hr_intraday, df_hr_daily, personal_cfg)
+
+    print(f"\nMeta:")
+    for k, v in meta.items():
+        print(f"  {k}: {v}")
+
+    print(f"\nDaily data:")
+    for day in daily_list:
+        print(f"  {day}")
+
+    # アサーション: bounds が厳密単調増加
+    bounds = meta['bounds']
+    resting_hr = meta['resting_hr']
+    max_hr = meta['max_hr']
+
+    prev_val = None
+    for zone in ZONE_NAMES:
+        val = bounds[zone]
+        if prev_val is not None:
+            assert val > prev_val, f"bounds not strictly monotone: {bounds}"
+        prev_val = val
+
+    # resting_hr < Z1 < Z2 < Z3 < Z4 < Z5 < max_hr
+    assert resting_hr < bounds['Z1'], f"resting_hr({resting_hr}) >= Z1({bounds['Z1']})"
+    assert bounds['Z5'] < max_hr, f"Z5({bounds['Z5']}) >= max_hr({max_hr})"
+
+    print("\nSMOKE OK")

--- a/src/lib/analytics/mind.py
+++ b/src/lib/analytics/mind.py
@@ -340,7 +340,7 @@ def prepare_responsiveness_daily_data(start_date, end_date, df_hrv, df_heart_rat
     return responsiveness_data
 
 
-def prepare_exertion_balance_daily_data(start_date, end_date, df_activity, df_azm):
+def prepare_exertion_balance_daily_data(start_date, end_date, df_activity, df_zone):
     """
     運動バランスの日別データを準備
 
@@ -348,7 +348,7 @@ def prepare_exertion_balance_daily_data(start_date, end_date, df_activity, df_az
         start_date: 開始日
         end_date: 終了日
         df_activity: アクティビティデータフレーム（index=date）
-        df_azm: アクティブゾーン分データフレーム（index=date）
+        df_zone: calc_daily_zone_minutes() の戻り値（index=正規化日付）
 
     Returns:
         list[dict]: 日別データリスト
@@ -378,130 +378,34 @@ def prepare_exertion_balance_daily_data(start_date, end_date, df_activity, df_az
             row['fairly_min'] = None
             row['very_min'] = None
 
-        # アクティブゾーン分
-        if df_azm is not None and date in df_azm.index:
-            val = pd.to_numeric(df_azm.loc[date, 'activeZoneMinutes'], errors='coerce')
-            row['active_zone_minutes'] = int(val) if pd.notna(val) else None
-            val = pd.to_numeric(df_azm.loc[date, 'fatBurnActiveZoneMinutes'], errors='coerce')
-            row['fat_burn'] = float(val) if pd.notna(val) else None
-            val = pd.to_numeric(df_azm.loc[date, 'cardioActiveZoneMinutes'], errors='coerce')
-            row['cardio'] = float(val) if pd.notna(val) else None
-            val = pd.to_numeric(df_azm.loc[date, 'peakActiveZoneMinutes'], errors='coerce')
-            row['peak'] = float(val) if pd.notna(val) else None
+        # 心拍ゾーン分（calc_daily_zone_minutes の戻り値から取得）
+        if df_zone is not None and date in df_zone.index:
+            val = pd.to_numeric(df_zone.loc[date, 'z1_min'], errors='coerce')
+            row['z1_min'] = int(val) if pd.notna(val) else None
+            val = pd.to_numeric(df_zone.loc[date, 'z2_min'], errors='coerce')
+            row['z2_min'] = int(val) if pd.notna(val) else None
+            val = pd.to_numeric(df_zone.loc[date, 'z3_min'], errors='coerce')
+            row['z3_min'] = int(val) if pd.notna(val) else None
+            val = pd.to_numeric(df_zone.loc[date, 'z4_min'], errors='coerce')
+            row['z4_min'] = int(val) if pd.notna(val) else None
+            val = pd.to_numeric(df_zone.loc[date, 'z5_min'], errors='coerce')
+            row['z5_min'] = int(val) if pd.notna(val) else None
+            val = pd.to_numeric(df_zone.loc[date, 'total_zone_min'], errors='coerce')
+            row['total_zone_min'] = int(val) if pd.notna(val) else None
         else:
-            row['active_zone_minutes'] = None
-            row['fat_burn'] = None
-            row['cardio'] = None
-            row['peak'] = None
+            row['z1_min'] = None
+            row['z2_min'] = None
+            row['z3_min'] = None
+            row['z4_min'] = None
+            row['z5_min'] = None
+            row['total_zone_min'] = None
 
         exertion_data.append(row)
 
     return exertion_data
 
 
-def prepare_sleep_patterns_daily_data(start_date, end_date, df_sleep, df_levels=None):
-    """
-    睡眠パターンの日別データを準備
-
-    Args:
-        start_date: 開始日
-        end_date: 終了日
-        df_sleep: 睡眠データフレーム（dateOfSleep列あり）
-        df_levels: 睡眠レベルデータフレーム（sleep_levels.csv、オプショナル）
-
-    Returns:
-        list[dict]: 日別データリスト（入眠潜時・起床後時間含む）
-    """
-    from lib.analytics.sleep import calc_sleep_timing
-
-    sleep_data = []
-    all_dates = pd.date_range(start=start_date, end=end_date, freq='D')
-
-    # 入眠潜時・起床後時間を計算（df_levelsが提供されている場合）
-    sleep_timing = {}
-    if df_levels is not None and not df_levels.empty:
-        raw_timing = calc_sleep_timing(df_levels)
-        # キーを日付文字列('YYYY-MM-DD')に正規化（calc_sleep_timingはdatetime型キーを返す場合がある）
-        for key, value in raw_timing.items():
-            date_key = pd.to_datetime(key).strftime('%Y-%m-%d')
-            sleep_timing[date_key] = value
-
-    for date in all_dates:
-        row = {'date': date}
-        date_str = date.strftime('%Y-%m-%d')
-
-        # 睡眠データ
-        if df_sleep is not None:
-            sleep_day = df_sleep[df_sleep['dateOfSleep'] == date]
-            if len(sleep_day) > 0:
-                # 就寝時刻
-                if 'startTime' in sleep_day.columns:
-                    start_time = sleep_day.iloc[0]['startTime']
-                    if pd.notna(start_time):
-                        row['bedtime'] = pd.to_datetime(start_time).strftime('%H:%M')
-                    else:
-                        row['bedtime'] = None
-                else:
-                    row['bedtime'] = None
-
-                # 起床時刻
-                if 'endTime' in sleep_day.columns:
-                    end_time = sleep_day.iloc[0]['endTime']
-                    if pd.notna(end_time):
-                        row['waketime'] = pd.to_datetime(end_time).strftime('%H:%M')
-                    else:
-                        row['waketime'] = None
-                else:
-                    row['waketime'] = None
-
-                # 睡眠時間
-                val = sleep_day.iloc[0]['minutesAsleep']
-                row['sleep_hours'] = float(val) / 60 if pd.notna(val) else None
-
-                # 効率
-                val = sleep_day.iloc[0]['efficiency']
-                row['efficiency'] = float(val) if pd.notna(val) else None
-
-                # 覚醒時間（分）
-                if 'minutesAwake' in sleep_day.columns:
-                    val = sleep_day.iloc[0]['minutesAwake']
-                    row['minutes_awake'] = float(val) if pd.notna(val) else None
-                else:
-                    row['minutes_awake'] = None
-
-                # 中途覚醒回数
-                if 'wakeCount' in sleep_day.columns:
-                    val = sleep_day.iloc[0]['wakeCount']
-                    row['wake_count'] = int(val) if pd.notna(val) else None
-                else:
-                    row['wake_count'] = None
-            else:
-                row['bedtime'] = None
-                row['waketime'] = None
-                row['sleep_hours'] = None
-                row['efficiency'] = None
-                row['minutes_awake'] = None
-                row['wake_count'] = None
-        else:
-            row['bedtime'] = None
-            row['waketime'] = None
-            row['sleep_hours'] = None
-            row['efficiency'] = None
-            row['minutes_awake'] = None
-            row['wake_count'] = None
-
-        # 入眠潜時・起床後時間（sleep_timingから取得）
-        if date_str in sleep_timing:
-            timing = sleep_timing[date_str]
-            row['minutes_to_fall_asleep'] = timing.get('minutes_to_fall_asleep')
-            row['minutes_after_wakeup'] = timing.get('minutes_after_wakeup')
-        else:
-            row['minutes_to_fall_asleep'] = None
-            row['minutes_after_wakeup'] = None
-
-        sleep_data.append(row)
-
-    return sleep_data
+from lib.analytics.mind_sleep import prepare_sleep_patterns_daily_data  # noqa: F401
 
 
 # ベースライン計算期間の定義

--- a/src/lib/analytics/mind_sleep.py
+++ b/src/lib/analytics/mind_sleep.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+# coding: utf-8
+"""
+メンタルレポート用 睡眠パターンデータ準備
+
+mind.py から分離したモジュール。
+"""
+
+import pandas as pd
+
+
+def prepare_sleep_patterns_daily_data(start_date, end_date, df_sleep, df_levels=None):
+    """
+    睡眠パターンの日別データを準備
+
+    Args:
+        start_date: 開始日
+        end_date: 終了日
+        df_sleep: 睡眠データフレーム（dateOfSleep列あり）
+        df_levels: 睡眠レベルデータフレーム（sleep_levels.csv、オプショナル）
+
+    Returns:
+        list[dict]: 日別データリスト（入眠潜時・起床後時間含む）
+    """
+    from lib.analytics.sleep import calc_sleep_timing
+
+    sleep_data = []
+    all_dates = pd.date_range(start=start_date, end=end_date, freq='D')
+
+    # 入眠潜時・起床後時間を計算（df_levelsが提供されている場合）
+    sleep_timing = {}
+    if df_levels is not None and not df_levels.empty:
+        raw_timing = calc_sleep_timing(df_levels)
+        # キーを日付文字列('YYYY-MM-DD')に正規化（calc_sleep_timingはdatetime型キーを返す場合がある）
+        for key, value in raw_timing.items():
+            date_key = pd.to_datetime(key).strftime('%Y-%m-%d')
+            sleep_timing[date_key] = value
+
+    for date in all_dates:
+        row = {'date': date}
+        date_str = date.strftime('%Y-%m-%d')
+
+        # 睡眠データ
+        if df_sleep is not None:
+            sleep_day = df_sleep[df_sleep['dateOfSleep'] == date]
+            if len(sleep_day) > 0:
+                # 就寝時刻
+                if 'startTime' in sleep_day.columns:
+                    start_time = sleep_day.iloc[0]['startTime']
+                    if pd.notna(start_time):
+                        row['bedtime'] = pd.to_datetime(start_time).strftime('%H:%M')
+                    else:
+                        row['bedtime'] = None
+                else:
+                    row['bedtime'] = None
+
+                # 起床時刻
+                if 'endTime' in sleep_day.columns:
+                    end_time = sleep_day.iloc[0]['endTime']
+                    if pd.notna(end_time):
+                        row['waketime'] = pd.to_datetime(end_time).strftime('%H:%M')
+                    else:
+                        row['waketime'] = None
+                else:
+                    row['waketime'] = None
+
+                # 睡眠時間
+                val = sleep_day.iloc[0]['minutesAsleep']
+                row['sleep_hours'] = float(val) / 60 if pd.notna(val) else None
+
+                # 効率
+                val = sleep_day.iloc[0]['efficiency']
+                row['efficiency'] = float(val) if pd.notna(val) else None
+
+                # 覚醒時間（分）
+                if 'minutesAwake' in sleep_day.columns:
+                    val = sleep_day.iloc[0]['minutesAwake']
+                    row['minutes_awake'] = float(val) if pd.notna(val) else None
+                else:
+                    row['minutes_awake'] = None
+
+                # 中途覚醒回数
+                if 'wakeCount' in sleep_day.columns:
+                    val = sleep_day.iloc[0]['wakeCount']
+                    row['wake_count'] = int(val) if pd.notna(val) else None
+                else:
+                    row['wake_count'] = None
+            else:
+                row['bedtime'] = None
+                row['waketime'] = None
+                row['sleep_hours'] = None
+                row['efficiency'] = None
+                row['minutes_awake'] = None
+                row['wake_count'] = None
+        else:
+            row['bedtime'] = None
+            row['waketime'] = None
+            row['sleep_hours'] = None
+            row['efficiency'] = None
+            row['minutes_awake'] = None
+            row['wake_count'] = None
+
+        # 入眠潜時・起床後時間（sleep_timingから取得）
+        if date_str in sleep_timing:
+            timing = sleep_timing[date_str]
+            row['minutes_to_fall_asleep'] = timing.get('minutes_to_fall_asleep')
+            row['minutes_after_wakeup'] = timing.get('minutes_after_wakeup')
+        else:
+            row['minutes_to_fall_asleep'] = None
+            row['minutes_after_wakeup'] = None
+
+        sleep_data.append(row)
+
+    return sleep_data

--- a/templates/body/sections/training.md.j2
+++ b/templates/body/sections/training.md.j2
@@ -2,6 +2,7 @@
 
 {% if aerobic_data %}
 > 歩数と活動強度の記録。心拍ゾーン（%HRR カルボーネン法, maxHR=Tanaka{{ hr_zone_meta.max_hr }}/RHR{{ hr_zone_meta.resting_hr|number_format(0) }}）: Z1回復 Z2有酸素 Z3テンポ Z4閾値 Z5VO2max
+> 境界(bpm): Z1≥{{ hr_zone_meta.bounds.Z1|number_format(0) }} / Z2≥{{ hr_zone_meta.bounds.Z2|number_format(0) }} / Z3≥{{ hr_zone_meta.bounds.Z3|number_format(0) }} / Z4≥{{ hr_zone_meta.bounds.Z4|number_format(0) }} / Z5≥{{ hr_zone_meta.bounds.Z5|number_format(0) }}
 
 | 日付 | 歩数 | Zone合計 | Z1 | Z2 | Z3 | Z4 | Z5 | VO2 Max |
 |------|------|----------|----|----|----|----|-----|---------|

--- a/templates/body/sections/training.md.j2
+++ b/templates/body/sections/training.md.j2
@@ -1,13 +1,12 @@
 ## 🏋️ トレーニング
 
 {% if aerobic_data %}
-> 歩数と活動強度の記録。Active Zoneは心拍数ベースの運動強度（週150分推奨）。
-> Zone内訳: Z2（50-69% HRmax）、Z3-4（70-84%）、Z5（85%+）
+> 歩数と活動強度の記録。心拍ゾーン（%HRR カルボーネン法, maxHR=Tanaka{{ hr_zone_meta.max_hr }}/RHR{{ hr_zone_meta.resting_hr|number_format(0) }}）: Z1回復 Z2有酸素 Z3テンポ Z4閾値 Z5VO2max
 
-| 日付 | 歩数 | Zone合計 | Z2 | Z3-4 | Z5 | VO2 Max |
-|------|------|----------|----|------|-----|---------|
+| 日付 | 歩数 | Zone合計 | Z1 | Z2 | Z3 | Z4 | Z5 | VO2 Max |
+|------|------|----------|----|----|----|----|-----|---------|
 {% for row in aerobic_data %}
-| {{ row.date | date_format }} | {{ row.steps | number_format(0) }} | {{ row.active_zone | number_format(0) }} | {{ row.fat_burn | number_format(0) }} | {{ row.cardio | number_format(0) }} | {{ row.peak | number_format(0) }} | {{ row.vo2max | number_format(0) }} |
+| {{ row.date | date_format }} | {{ row.steps | number_format(0) }} | {{ row.total_zone_min | number_format(0) }} | {{ row.z1_min | number_format(0) }} | {{ row.z2_min | number_format(0) }} | {{ row.z3_min | number_format(0) }} | {{ row.z4_min | number_format(0) }} | {{ row.z5_min | number_format(0) }} | {{ row.vo2max | number_format(0) }} |
 {% endfor %}
 {% endif %}
 

--- a/templates/mind/sections/exertion_balance.md.j2
+++ b/templates/mind/sections/exertion_balance.md.j2
@@ -2,14 +2,17 @@
 
 身体活動レベルとバランスを評価
 
-| 日付 | 歩数 | AZM合計 |
-|------|------|---------|
+> 心拍ゾーン（%HRR カルボーネン法）: maxHR={{ hr_zone_meta.max_hr }} / 安静時HR={{ hr_zone_meta.resting_hr | number_format(0) }} / 直近{{ hr_zone_meta.window_days }}日中央値固定
+> 境界(bpm): Z1≥{{ hr_zone_meta.bounds.Z1|number_format(0) }} / Z2≥{{ hr_zone_meta.bounds.Z2|number_format(0) }} / Z3≥{{ hr_zone_meta.bounds.Z3|number_format(0) }} / Z4≥{{ hr_zone_meta.bounds.Z4|number_format(0) }} / Z5≥{{ hr_zone_meta.bounds.Z5|number_format(0) }}
+
+| 日付 | 歩数 | Z1 | Z2 | Z3 | Z4 | Z5 | 合計 |
+|------|------|----|----|----|----|----|------|
 {% for day in exertion_balance_data %}
-| {{ day.date.strftime('%m-%d') }} | {{ day.steps|number_format(0) if day.steps else '-' }} | {{ day.active_zone_minutes|number_format(0) if day.active_zone_minutes else '-' }} |
+| {{ day.date.strftime('%m-%d') }} | {{ day.steps|number_format(0) if day.steps else '-' }} | {{ day.z1_min|number_format(0) if day.z1_min is not none else '-' }} | {{ day.z2_min|number_format(0) if day.z2_min is not none else '-' }} | {{ day.z3_min|number_format(0) if day.z3_min is not none else '-' }} | {{ day.z4_min|number_format(0) if day.z4_min is not none else '-' }} | {{ day.z5_min|number_format(0) if day.z5_min is not none else '-' }} | {{ day.total_zone_min|number_format(0) if day.total_zone_min is not none else '-' }} |
 {% endfor %}
 
 **解釈**:
-- 週150分以上のアクティブゾーン分が推奨される
+- Z2(有酸素)中心の有酸素ベース構築が土台。週合計でZ1-2の低強度volumeを確保
 - 1日8,000歩以上が健康的な目標
 
 ---


### PR DESCRIPTION
## 概要

- `config/personal.yaml`（汎用個人プロファイル, birth_date 単一真実 → age 自動算出）を新設
- `src/lib/analytics/hr_zones.py` 新規: Tanaka式maxHR・カルボーネン%HRR・安静時HR直近30日中央値（レポート終了日基準・期間内固定）でゾーン境界を算出
- mind/body 両レポートの運動ゾーン表示を旧 Fitbit AZM（fat_burn/cardio/peak）から独自 Z1-Z5 に完全置換、body 注記「Z2（50-69% HRmax）」を %HRR 表記＋境界bpm明示に修正
- 採用根拠を `docs/adr/001-hr-zone-algorithm.md` に文書化
- Fitbit AZM 取得パイプライン（fitbit_api.py / fitbit_fetcher.py / active_zone_minutes.csv）は温存（後続の比較issue用）
- 付随変更: mind.py が 500 行ファイルサイズ制限に達したため `prepare_sleep_patterns_daily_data` を `src/lib/analytics/mind_sleep.py` に分離
- body の RHR 計算基準日を target_end に統一し、mind/body/smoke の3経路でゾーン境界が完全一致することを確認

Closes #18

## テスト計画

- [ ] `python src/lib/analytics/hr_zones.py` → "SMOKE OK"、bounds 単調増加 assert パス
- [ ] `python scripts/generate_mind_report_daily.py --days 7` → エラーなし完了、運動バランス表に Z1-Z5 と境界(bpm)注記
- [ ] `python scripts/generate_body_report_daily.py --days 30` → エラーなし完了、トレーニング表に Z1-Z5 列＋境界(bpm)注記
- [ ] mind --days 7 / body --days 30 / smoke の resting_hr・Z1-Z5境界が完全一致（レポート種別非依存の回帰）
- [ ] `config/personal.yaml` の `hr_zones.max_hr_override` に数値を入れると Tanaka 推定を上書きできる
- [ ] Fitbit AZM 取得パイプライン（fitbit_api.py / fitbit_fetcher.py / active_zone_minutes.csv）が温存され壊れていない

---
🤖 Claude Code session: `a069088c-87b6-49c0-a1d3-139b5f33ef85`