### PR TITLE
fix: HealthPlanetのログイン破損を修正し血圧計データ取得を追加

### DIFF
--- a/scripts/fetch_healthplanet.py
+++ b/scripts/fetch_healthplanet.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8
 """
-HealthPlanet 体組成計データ取得スクリプト
+HealthPlanet 体組成計・血圧計データ取得スクリプト
 非公式APIを使用して全データを取得
 """
 
@@ -19,6 +19,7 @@ from lib.utils import csv_utils
 BASE_DIR = Path(__file__).parent.parent
 CREDS_FILE = BASE_DIR / 'config/healthplanet_creds.json'
 OUT_FILE = BASE_DIR / 'data/healthplanet_innerscan.csv'
+BP_OUT_FILE = BASE_DIR / 'data/healthplanet_bp.csv'
 
 
 def load_creds():
@@ -29,6 +30,8 @@ def load_creds():
 def main():
     parser = argparse.ArgumentParser(description='HealthPlanet体組成計データ取得')
     parser.add_argument('--overwrite', action='store_true', help='既存データを上書き（デフォルトは追記）')
+    parser.add_argument('--days', type=int, default=60,
+                        help='取得日数（90と365は粒度が変わるため使用不可）')
     args = parser.parse_args()
 
     creds = load_creds()
@@ -37,10 +40,18 @@ def main():
     session = hp.create_login_session(creds['login_id'], creds['password'])
 
     print("体組成計データを取得中...")
-    records = hp.get_innerscan_data(session, days=14)
+    save_records(hp.get_innerscan_data(session, days=args.days),
+                 OUT_FILE, args.overwrite)
 
+    print("血圧計データを取得中...")
+    save_records(hp.get_blood_pressure_data(session, days=args.days),
+                 BP_OUT_FILE, args.overwrite)
+
+
+def save_records(records, out_file, overwrite):
+    """{日付: {列: 値}} をCSVに保存（デフォルトは既存データへ追記）"""
     if not records:
-        print("データがありません")
+        print("  データがありません")
         return
 
     df = pd.DataFrame.from_dict(records, orient='index')
@@ -48,13 +59,12 @@ def main():
     df.index.name = 'date'
     df.sort_index(inplace=True)
 
-    if not args.overwrite:
-        df = csv_utils.merge_csv(df, OUT_FILE, 'date')
+    if not overwrite:
+        df = csv_utils.merge_csv(df, out_file, 'date')
 
-    df.to_csv(OUT_FILE)
-    print(f"データを保存しました: {OUT_FILE}")
-    print(f"総レコード数: {len(df)}")
-    print(df.tail())
+    df.to_csv(out_file)
+    print(f"  保存しました: {out_file} ({len(df)}件)")
+    print(df.tail(3))
 
 
 if __name__ == '__main__':

--- a/scripts/generate_mind_report_daily.py
+++ b/scripts/generate_mind_report_daily.py
@@ -37,6 +37,7 @@ SPO2_CSV = BASE_DIR / 'data/fitbit/spo2.csv'
 CARDIO_SCORE_CSV = BASE_DIR / 'data/fitbit/cardio_score.csv'
 TEMPERATURE_SKIN_CSV = BASE_DIR / 'data/fitbit/temperature_skin.csv'
 ACTIVITY_CSV = BASE_DIR / 'data/fitbit/activity.csv'
+BLOOD_PRESSURE_CSV = BASE_DIR / 'data/healthplanet_bp.csv'
 ACTIVITY_LOGS_CSV = BASE_DIR / 'data/fitbit/activity_logs.csv'
 
 
@@ -616,6 +617,13 @@ def main():
             baseline_window=mind.BASELINE_WINDOWS['temp_variation']
         )
 
+    # 血圧（ベースライン不要、表示期間のみ）
+    if BLOOD_PRESSURE_CSV.exists():
+        data['blood_pressure'] = load_csv_with_baseline_window(
+            BLOOD_PRESSURE_CSV, target_start, target_end,
+            baseline_window=0
+        )
+
     # アクティビティ（ベースライン不要、表示期間のみ）
     if ACTIVITY_CSV.exists():
         data['activity'] = load_csv_with_baseline_window(
@@ -722,7 +730,8 @@ def main():
         df_heart_rate=data.get('heart_rate'),
         df_breathing=data.get('breathing_rate'),
         df_temp=data.get('temperature_skin'),
-        df_spo2=data.get('spo2')
+        df_spo2=data.get('spo2'),
+        df_bp=data.get('blood_pressure')
     )
 
     # 心拍ゾーン算出（hr_zones ライブラリ使用）

--- a/src/lib/analytics/mind.py
+++ b/src/lib/analytics/mind.py
@@ -162,7 +162,7 @@ def format_trend(trend):
     return mapping.get(trend, '→ 安定')
 
 
-def prepare_responsiveness_daily_data(start_date, end_date, df_hrv, df_heart_rate, df_breathing, df_temp, df_spo2=None):
+def prepare_responsiveness_daily_data(start_date, end_date, df_hrv, df_heart_rate, df_breathing, df_temp, df_spo2=None, df_bp=None):
     """
     反応性の日別データを準備（ベースライン情報含む）
 
@@ -174,6 +174,7 @@ def prepare_responsiveness_daily_data(start_date, end_date, df_hrv, df_heart_rat
         df_breathing: 呼吸数データフレーム（index=date、ベースライン計算済み）
         df_temp: 皮膚温データフレーム（index=date、ベースライン計算済み）
         df_spo2: SpO2データフレーム（index=date、ベースライン計算済み）
+        df_bp: 血圧データフレーム（index=date、HealthPlanet血圧計）
 
     Returns:
         list[dict]: 日別データリスト（ベースライン乖離情報含む）
@@ -308,6 +309,15 @@ def prepare_responsiveness_daily_data(start_date, end_date, df_hrv, df_heart_rat
             row['spo2_avg_baseline_std'] = None
             row['spo2_avg_deviation_pct'] = None
             row['spo2_avg_z_score'] = None
+
+        # 血圧（HealthPlanet血圧計、手動測定日のみ）
+        # 記録開始間もなくベースラインが引けないため、実測値のみを持たせる
+        for col in ('bp_systolic', 'bp_diastolic', 'bp_pulse'):
+            if df_bp is not None and date in df_bp.index and col in df_bp.columns:
+                val = df_bp.loc[date, col]
+                row[col] = float(val) if pd.notna(val) else None
+            else:
+                row[col] = None
 
         # 皮膚温変動
         if df_temp is not None and date in df_temp.index:

--- a/src/lib/clients/healthplanet_unofficial.py
+++ b/src/lib/clients/healthplanet_unofficial.py
@@ -7,6 +7,8 @@ HealthPlanet 非公式 graph.json API
 注意: 非公式な方法のため、将来使えなくなる可能性あり
 """
 
+import re
+
 import requests
 from collections import defaultdict
 
@@ -26,6 +28,11 @@ INNERSCAN_KINDS = {
     22: 'body_water_rate',
     23: 'muscle_quality_score',
 }
+
+# 血圧計のkind番号
+# kind=10 は他のkindと違い value1=収縮期 / value_ext=拡張期 のペアで返る
+BP_KIND_PRESSURE = 10
+BP_KIND_PULSE = 11
 
 # 全てのkind番号（参考用）
 ALL_KINDS = {
@@ -59,27 +66,54 @@ ALL_KINDS = {
 
 
 def create_login_session(login_id, password):
-    """Webログインセッションを作成"""
+    """Webログインセッションを作成
+
+    login.do のフォームは Struts の CSRF トークン
+    (org.apache.struts.taglib.html.TOKEN) を要求する。
+    ログインページから毎回スクレイプして同じ POST に載せる。
+    """
     session = requests.Session()
-    session.get(f"{BASE_URL}/login.do")
+
+    resp = session.get(f"{BASE_URL}/login.do")
+    resp.raise_for_status()
+    html = resp.content.decode('shift_jis', errors='replace')
+
+    match = re.search(
+        r'name="org\.apache\.struts\.taglib\.html\.TOKEN"\s+value="([^"]+)"',
+        html,
+    )
+    if not match:
+        raise RuntimeError("ログインページからCSRFトークンを取得できません（フォーム仕様変更の可能性）")
 
     login_data = {
+        'org.apache.struts.taglib.html.TOKEN': match.group(1),
         'loginId': login_id,
         'passwd': password,
-        'send': '1'
+        'send': '1',
+        'url': '',
+        'auto': 'on',
     }
 
-    response = session.post(f"{BASE_URL}/login_oauth.do", data=login_data)
+    response = session.post(f"{BASE_URL}/login.do", data=login_data)
     response.raise_for_status()
+
+    # 失敗時はログイン画面が返るだけで 200 になるため、内容で判定する
+    body = response.content.decode('shift_jis', errors='replace')
+    if 'loginId' in body:
+        raise RuntimeError("HealthPlanetのログインに失敗しました（認証情報またはフォーム仕様を確認）")
+
     return session
 
 
-def get_innerscan_data(session, days=90, kinds=None):
+def get_innerscan_data(session, days=60, kinds=None):
     """体組成計データを取得
 
     Args:
         session: ログイン済みセッション
-        days: 取得日数
+        days: 取得日数。graph.json は値によって粒度が変わる。
+            14/30/60/120 は実測日そのままの日次だが、90 は日付がずれる
+            バケット集約、365 は月次平均になるため使わないこと
+
         kinds: 取得するkind番号の辞書 {kind: col_name}。Noneの場合はINNERSCAN_KINDS
 
     Returns:
@@ -91,15 +125,61 @@ def get_innerscan_data(session, days=90, kinds=None):
     records = defaultdict(dict)
 
     for kind, col_name in kinds.items():
-        params = {'day': days, 'page': 1, 'kind': kind}
-        response = session.get(GRAPH_URL, params=params)
-        response.raise_for_status()
-
-        data = response.json()
-        if data.get('code', [-1])[0] != 0:
+        data = _fetch_kind(session, kind, days)
+        if data is None:
             continue
 
-        for date_str, value in data.get('value1', []):
+        for date_str, value in _series(data, 'value1'):
             records[date_str][col_name] = value
+
+    return dict(records)
+
+
+def _series(data, key):
+    """graph.json のデータ系列を (日付, 値) のリストで返す
+
+    値が無い系列は null そのものだけでなく [null] のように
+    None 要素を含むリストで返ることがあるため、両方を潰す。
+    """
+    return [pair for pair in (data.get(key) or []) if pair]
+
+
+def _fetch_kind(session, kind, days):
+    """graph.json を1 kind分取得。データが無い場合は None"""
+    response = session.get(GRAPH_URL, params={'day': days, 'page': 1, 'kind': kind})
+    response.raise_for_status()
+
+    data = response.json()
+    if data.get('code', [-1])[0] != 0:
+        return None
+    return data
+
+
+def get_blood_pressure_data(session, days=60):
+    """血圧計データ（収縮期・拡張期・脈拍）を取得
+
+    kind=10 は value1 に収縮期、value_ext に拡張期が入るペア構造で返るため、
+    value1 しか見ない get_innerscan_data では拡張期を取りこぼす。
+
+    Args:
+        session: ログイン済みセッション
+        days: 取得日数（get_innerscan_data と同じ粒度の制約がある）
+
+    Returns:
+        dict: {date_str: {'bp_systolic': .., 'bp_diastolic': .., 'bp_pulse': ..}, ...}
+    """
+    records = defaultdict(dict)
+
+    pressure = _fetch_kind(session, BP_KIND_PRESSURE, days)
+    if pressure is not None:
+        for date_str, value in _series(pressure, 'value1'):
+            records[date_str]['bp_systolic'] = value
+        for date_str, value in _series(pressure, 'value_ext'):
+            records[date_str]['bp_diastolic'] = value
+
+    pulse = _fetch_kind(session, BP_KIND_PULSE, days)
+    if pulse is not None:
+        for date_str, value in _series(pulse, 'value1'):
+            records[date_str]['bp_pulse'] = value
 
     return dict(records)

--- a/templates/mind/sections/responsiveness.md.j2
+++ b/templates/mind/sections/responsiveness.md.j2
@@ -21,15 +21,16 @@
 
 ### 📅 日別データ
 
-| 日付 | HRV | RHR | BR | SpO2 | 体温Δ |
-|------|-----|-----|----|----|------|
+| 日付 | HRV | RHR | BR | SpO2 | 体温Δ | 血圧 | 脈拍 |
+|------|-----|-----|----|----|------|------|------|
 {% for day in responsiveness_data %}
-| {{ day.date.strftime('%m-%d') }} | {{ day.hrv_daily|number_format(1) if day.hrv_daily else '-' }} | {{ day.rhr|number_format(0) if day.rhr else '-' }} | {{ day.breathing_rate|number_format(1) if day.breathing_rate else '-' }} | {% if day.spo2_min and day.spo2_avg %}{{ day.spo2_min|number_format(1) }}/{{ day.spo2_avg|number_format(1) }}{% else %}-{% endif %} | {{ day.temp_variation|number_format(2) if day.temp_variation else '-' }} |
+| {{ day.date.strftime('%m-%d') }} | {{ day.hrv_daily|number_format(1) if day.hrv_daily else '-' }} | {{ day.rhr|number_format(0) if day.rhr else '-' }} | {{ day.breathing_rate|number_format(1) if day.breathing_rate else '-' }} | {% if day.spo2_min and day.spo2_avg %}{{ day.spo2_min|number_format(1) }}/{{ day.spo2_avg|number_format(1) }}{% else %}-{% endif %} | {{ day.temp_variation|number_format(2) if day.temp_variation else '-' }} | {% if day.bp_systolic and day.bp_diastolic %}{{ day.bp_systolic|number_format(0) }}/{{ day.bp_diastolic|number_format(0) }}{% else %}-{% endif %} | {{ day.bp_pulse|number_format(0) if day.bp_pulse else '-' }} |
 {% endfor %}
 
 **凡例**:
 - **HRV**: 心拍変動（RMSSD, ms） / **RHR**: 安静時心拍数（bpm） / **BR**: 呼吸数（回/分）
 - **SpO2**: 血中酸素飽和度（最小/平均%、95%以上が正常）
 - **体温Δ**: 皮膚温変動（℃）
+- **血圧**: 収縮期/拡張期（mmHg、HealthPlanet血圧計） / **脈拍**: 血圧計の脈拍（拍/分）
 
 ---


### PR DESCRIPTION
## 背景

HealthPlanet の体組成データが **2026-07-09 以降ずっと欠測**していた。調査したところ、測定していなかったのではなく **スクレイパーが壊れて取得できていなかった**。

`login.do` のフォーム仕様が変わっており、2点が原因だった。

| | 旧コード | 実際 |
|---|---|---|
| POST 先 | `login_oauth.do` | `login.do` |
| CSRF | なし | `org.apache.struts.taglib.html.TOKEN` が必須 |

さらに悪いことに、**認証失敗時もログイン画面が HTTP 200 で返る**ため例外にならず、`graph.json` が全 kind で `code: -1` を返し、`get_innerscan_data` がそれを黙って `continue` していた。結果として「データがありません」と表示されるだけで、異常として検知されないまま放置されていた。

## 変更内容

### ログイン修正
- `login.do` からCSRFトークンをスクレイプして同じPOSTに載せる（ページは Shift-JIS）
- POST先を `login.do` に変更
- **ログイン成否をレスポンス本文で判定し、失敗時は例外を送出**。同じ黙殺が再発しないようにした

### 血圧計データ取得の追加
- `get_blood_pressure_data()` を追加。`kind=10` は他のkindと違い **`value1`=収縮期 / `value_ext`=拡張期 のペア構造**で返るため、`value1` しか見ない `get_innerscan_data` では拡張期を取りこぼす
- 値の無い系列は `null` そのものではなく `[null]` のように **None要素を含むリスト**で返ることがあるため、`_series()` ヘルパーで両方を潰す
- `data/healthplanet_bp.csv` に保存（`bp_systolic` / `bp_diastolic` / `bp_pulse`）
- mindレポートの反応性セクションに血圧・脈拍列を追加

### `day` パラメータの粒度の罠
`graph.json` の `day` は取得期間だけでなく**集約粒度も変える**。

| day | 挙動 |
|---|---|
| 14 / 30 / 60 / 120 | 実測日そのままの日次 ✅ |
| **90** | 日付がずれるバケット集約（06/24→06/25、07/28→07/29、08/15→08/16）❌ |
| **365** | 月次平均 ❌ |

`get_innerscan_data()` の**デフォルトが `days=90`** で、踏むと日付のずれた値が静かに混入する状態だった。デフォルトを60に変更し docstring に明記。

- `fetch_healthplanet.py` に `--days` を追加（従来は `days=14` 固定でバックフィル不可）

## 動作確認

型チェック基盤（mypy/ruff）とテストディレクトリが存在しないため、基盤は新設せず構文チェックと実データでの動作確認で検証した。

```
$ uv run python -m compileall -q <対象4ファイル>
compileall: OK
```

**欠測データのバックフィル**（3件復旧）:
```
$ uv run python scripts/fetch_healthplanet.py --days 60
体組成計データを取得中...
  保存しました: data/healthplanet_innerscan.csv (147件)
2026-07-28    62.0 ...   ← 復旧
2026-08-02    63.0 ...   ← 復旧
2026-08-15    63.1 ...   ← 復旧
血圧計データを取得中...
  保存しました: data/healthplanet_bp.csv (2件)
2026-08-17        104.0          59.0
2026-08-18         98.0          58.0
```

日次であることは既存CSV（06/21=62.2, 06/24=61.5, 07/09=60.8）と `day=60`/`120` の値が完全一致することで確認。

**レポート生成の回帰確認**（全7本）:
```
generate_body_report_daily.py --days 30       OK
generate_sleep_report_daily.py --days 30      OK
generate_mind_report_daily.py --days 14       OK
generate_mind_report_interval.py --weeks 4    OK
generate_body_report_interval.py --weeks 4    OK
generate_sleep_report_interval.py --weeks 4   OK
generate_workout_report_interval.py --weeks 4 OK
```

`prepare_responsiveness_daily_data` にキーワード引数 `df_bp` を追加したが、呼び出し元は `generate_mind_report_daily.py` の1箇所のみで既定値ありのため後方互換。

mindレポート出力:
```
| 日付 | HRV | RHR | BR | SpO2 | 体温Δ | 血圧 | 脈拍 |
| 08-17 | 29.2 | 57 | 16.2 | 93.5/96.7 | 1.00 | 104/59 | - |
| 08-18 | 28.6 | 56 | 15.8 | 92.0/95.2 | 0.60 | 98/58 | - |
```

脈拍は未記録のため `-`。今後の記録に備えて列は用意済み。

## スコープ外

`data/` 配下のライフログCSVと `reports/` の生成物は本PRに含めていない（プロジェクトの直コミット運用に従い分離）。

---
🤖 Claude Code session: `6d69d3a4-46f0-4cb7-8ecf-377ba565dbe8`
