### PR TITLE
fix: Fitbit APIの単位系をメートル法に固定

### DIFF
--- a/src/lib/clients/fitbit_api.py
+++ b/src/lib/clients/fitbit_api.py
@@ -11,6 +11,12 @@ import json
 import os
 import fitbit
 
+# Fitbit API は Accept-Language ヘッダで単位系が決まる。
+# python-fitbit の既定は en_US で、距離=マイル・体温=華氏で返る。
+# メートル法で受け取るため明示的に上書きする。
+# （python-fitbit の Fitbit.METRIC は 'en_UK' という綴り誤りのため使わない）
+UNIT_SYSTEM = 'en_GB'
+
 
 def load_token(token_file):
     """トークンをファイルから読み込み"""
@@ -45,7 +51,8 @@ def create_client(creds_file, token_file):
         oauth2=True,
         access_token=token_data['access_token'],
         refresh_token=token_data['refresh_token'],
-        refresh_cb=update_token
+        refresh_cb=update_token,
+        system=UNIT_SYSTEM
     )
 
     return client
@@ -87,7 +94,8 @@ def create_client_with_env(creds_file=None, token_file=None):
             oauth2=True,
             access_token=token_data['access_token'],
             refresh_token=token_data['refresh_token'],
-            refresh_cb=update_token
+            refresh_cb=update_token,
+            system=UNIT_SYSTEM
         )
 
         return client, updated_token
@@ -115,7 +123,8 @@ def create_client_with_env(creds_file=None, token_file=None):
         oauth2=True,
         access_token=token_data['access_token'],
         refresh_token=token_data['refresh_token'],
-        refresh_cb=update_token
+        refresh_cb=update_token,
+        system=UNIT_SYSTEM
     )
 
     return client, updated_token


### PR DESCRIPTION
## 背景

Fitbit から取得していた距離がマイル、体温が華氏だった。

python-fitbit の `Fitbit.__init__` は `system=US` (= `en_US`) が既定で、それが `Accept-Language` ヘッダとして送られる。Fitbit Web API はこのヘッダで単位系を決めるため、ヤード・ポンド法で返ってきていた。

```python
US = 'en_US'
METRIC = 'en_UK'          # python-fitbit 側の綴り誤り（正しくは en_GB）
system=US                 # 既定値
headers.update({'Accept-Language': self.system})
```

## 影響範囲（実測で確認）

同一期間を `en_US` / `en_GB` の両方で取得して差分を取った。

| リソース | en_US | en_GB |
|---|---|---|
| `activity.distance` | 1.414676 (mi) | **2.2767 (km)** |
| `activity_logs.distance` | `distanceUnit: Mile` | **`distanceUnit: Kilometer`** |
| `temperature_skin.nightlyRelative` | 1.0 / 0.6 (°F差) | **0.5 / 0.3 (°C差)** |
| `temperature_core` | 98.2 (°F) | **36.8 (°C)** |

特に問題だったのが皮膚温で、**Mindレポートは凡例に「体温Δ: 皮膚温変動（℃）」と書きながら華氏の値を表示していた**。変動幅を約1.8倍に見せており、逸脱の大きさを読み違える。

なお z-score はスケール不変なので、免疫ストレススコアの判定ロジック自体は影響を受けない。皮膚温の閾値はすべて z-score ベース（`temp_variation_z_score >= 1.5`）で、°F 前提の絶対閾値がないことを確認済み。

## 変更内容

- 定数 `UNIT_SYSTEM = 'en_GB'` を定義し、クライアント生成3箇所すべてに `system=UNIT_SYSTEM` を指定
- python-fitbit の `Fitbit.METRIC` は `'en_UK'` という綴り誤りのため使わない（実測では en_UK でもメートル法で返ったが、正しい `en_GB` を使う）

### 再取得が不要なもの

`activity_logs` は各行が `distanceUnit` を持つ自己記述的な構造で、`src/lib/analytics/activity.py:120` の変換が単位を見て分岐している。

```python
lambda r: r['distance'] * 1.609344 if r.get('distanceUnit') == 'Mile' else r['distance']
```

en_GB では `distanceUnit` が `Kilometer` になり変換がスキップされるため、**新旧が混在しても正しく集計される**。二重変換にはならない。

## 動作確認

```
$ uv run python -m compileall -q src/lib/clients/fitbit_api.py
compileall: OK

$ uv run python -c "...create_client_with_env(...); print(c.system)"
client.system = en_GB
create_client system = en_GB
```

ライブ取得がメートル法になることを確認:
```
$ uv run python scripts/fetch_fitbit.py -e activity --days 2
2026-08-17,1922.0,544.0,3329.0,2.2767,857.0,88.0,26.0,3.0
2026-08-18,828.0,284.0,1888.0,1.3097,181.0,51.0,7.0,1.0
```

レポート生成の回帰確認（全7本 OK）:
```
generate_body_report_daily.py --days 30       OK
generate_sleep_report_daily.py --days 30      OK
generate_mind_report_daily.py --days 14       OK
generate_mind_report_interval.py --weeks 4    OK
generate_body_report_interval.py --weeks 4    OK
generate_sleep_report_interval.py --weeks 4   OK
generate_workout_report_interval.py --weeks 4 OK
```

Mindレポートの体温Δが摂氏になった（08-15: 1.80 → **1.00**、08-18: 0.60 → **0.30**）。

## 既存データの扱い（別コミット）

`data/` は本PRに含めず直コミット運用で分離する。内訳:

- `temperature_skin.csv` — 2024-12-01 以降を `--overwrite` で再取得（474 → 509件）
- `temperature_core.csv` — 2026-02-01 以降を再取得（3 → 12件）。取り込み漏れも復旧
- `activity.csv` — 265日分の再取得は Fitbit のレート制限（150 req/hour）を超えるため、`distance` 列を `×1.609344` でその場変換。変換結果が API の en_GB 実測値と完全一致することを確認済み（08-17: 2.276700 vs API 2.2767）。この列は生成のみで参照箇所がゼロであることもリポジトリ全体の grep で確認

---
🤖 Claude Code session: `6d69d3a4-46f0-4cb7-8ecf-377ba565dbe8`