### PR TITLE
室内環境データ（CO2/温度/湿度）取得: Tuya Cloud API経由でLSENLTY CO2モニターから収集

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ uv sync
 uv run scripts/fetch_sleep.py        # Fitbit睡眠データ取得
 uv run scripts/fetch_healthplanet.py # HealthPlanet体組成計データ取得
 uv run scripts/fetch_toggl.py        # Toggl Trackタイムエントリ取得
+uv run scripts/fetch_environment.py  # 室内環境（CO2/温度/湿度）取得
 ```
 
 ## Project Structure
@@ -34,6 +35,7 @@ uv run scripts/fetch_toggl.py        # Toggl Trackタイムエントリ取得
   - `healthplanet_official.py` - HealthPlanet公式OAuth API（体重・体脂肪率のみ）
   - `healthplanet_unofficial.py` - HealthPlanet非公式API（全項目取得可）
   - `toggl_client.py` - Toggl Track API
+  - `tuya_client.py` - Tuya Cloud API（CO2モニター）
   - `templates/` - Jinja2テンプレートとレンダラー
     - `renderer.py` - レポートテンプレートレンダラー
     - `filters.py` - カスタムJinja2フィルタ
@@ -115,6 +117,9 @@ df_filtered = filter_dataframe_by_period(
 - `fitbit_creds.json` / `fitbit_token.json` - Fitbit API
 - `healthplanet_creds.json` - HealthPlanet API（login_id, password必須）
 - `toggl_creds.json` - Toggl Track API（api_token必須）
+- `tuya_creds.json` - Tuya Cloud API（api_region, api_key, api_secret, device_id 必須）
 - `gcloud_creds.json` - Google サービスアカウント（手動記録のGoogle Sheets取得用）
+
+`tuya_creds.json` の取得には Tuya IoT Platform でのセットアップ（Cloud Project作成 → Service API サブスクライブ → Link App Account）が人間の手作業で必要。Cloud Project の Trial アカウントは1ヶ月で期限切れするため、期限が近づいたら管理画面から延長申請すること。また Device Log Service は無料枠で過去7日分しか保持しない恒久仕様（Trialとは別問題）のため、`fetch_environment.py` は日次実行での差分蓄積が必須。
 
 Google Sheets クライアント（`src/lib/clients/gsheets_client.py`）は `config/gcloud_creds.json` を直接参照しない。環境変数 `GOOGLE_APPLICATION_CREDENTIALS` か既定パス `~/.config/gcp/gdrive-creds.json` を探すため、新マシンではどちらかを用意する（リポジトリの認証情報を使う場合は `ln -sf "$PWD/config/gcloud_creds.json" ~/.config/gcp/gdrive-creds.json`）。

--- a/config/tuya_creds.json.sample
+++ b/config/tuya_creds.json.sample
@@ -1,0 +1,6 @@
+{
+  "api_region": "us",
+  "api_key": "YOUR_API_KEY",
+  "api_secret": "YOUR_API_SECRET",
+  "device_id": "YOUR_DEVICE_ID"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "matplotlib>=3.10.9",
     "scipy>=1.17.1",
     "google-api-python-client>=2.197.0",
+    "tinytuya>=1.20.0",
 ]
 
 [tool.uv]

--- a/scripts/fetch_environment.py
+++ b/scripts/fetch_environment.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+# coding: utf-8
+"""
+室内環境データ（CO2/温度/湿度）取得スクリプト
+
+LSENLTY WiFi CO2モニター（Tuya系デバイス）から Tuya Cloud API 経由でログを取得し、
+JSTに変換して data/environment.csv に蓄積する。
+
+Tuya Cloud API は最大1週間分しか遡れないため、日次実行で差分を蓄積する前提。
+
+Usage:
+    python scripts/fetch_environment.py --days 7
+    python scripts/fetch_environment.py --raw
+    python scripts/fetch_environment.py --start-date 2026-08-12 --end-date 2026-08-19
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+import argparse
+import datetime as dt
+import json
+
+from lib.clients import tuya_client
+from lib.clients.tuya_client import TuyaCloudError
+from lib.utils import csv_utils
+
+BASE_DIR = Path(__file__).parent.parent
+CREDS_FILE = BASE_DIR / 'config' / 'tuya_creds.json'
+CSV_FILE = BASE_DIR / 'data' / 'environment.csv'
+
+REQUIRED_KEYS = ['api_region', 'api_key', 'api_secret', 'device_id']
+
+
+def load_creds() -> dict:
+    if not CREDS_FILE.exists():
+        print(f"⚠️ 認証情報ファイルが見つかりません: {CREDS_FILE}")
+        print("以下の手順で作成してください:")
+        print(f"  1. config/tuya_creds.json.sample を {CREDS_FILE} にコピーして値を埋める")
+        print("  2. Tuya IoT Platform (https://iot.tuya.com/) で Cloud Project を作成"
+              "（Data CenterはWestern America）")
+        print("  3. Service API に以下をサブスクライブしてAuthorize: Industry Basic Service / "
+              "Smart Home Basic Service / Device Status Notification / Authorization / "
+              "IoT Core / Smart Home Scene Linkage / IoT Data Analytics")
+        print("  4. Devices → Link App Account でSmart LifeアカウントをQRスキャン連携")
+        print("  5. `uv run python -m tinytuya wizard` を実行して device_id / local_key を取得")
+        sys.exit(1)
+
+    with open(CREDS_FILE, 'r') as f:
+        creds = json.load(f)
+
+    missing = [k for k in REQUIRED_KEYS if not creds.get(k)]
+    if missing:
+        print(f"⚠️ 認証情報に不足しているキーがあります: {missing}")
+        print(f"  {CREDS_FILE} を確認してください（必須キー: {REQUIRED_KEYS}）")
+        sys.exit(1)
+
+    return creds
+
+
+def resolve_period(args) -> tuple[dt.date, dt.date]:
+    """引数から取得期間を決定"""
+    end = dt.date.today()
+    if args.start_date and args.end_date:
+        return (dt.datetime.strptime(args.start_date, '%Y-%m-%d').date(),
+                dt.datetime.strptime(args.end_date, '%Y-%m-%d').date())
+    return end - dt.timedelta(days=args.days - 1), end
+
+
+def main():
+    parser = argparse.ArgumentParser(description='室内環境データ（CO2/温度/湿度）取得')
+    parser.add_argument('--days', type=int, default=7, help='取得日数（今日から遡る）')
+    parser.add_argument('--start-date', type=str, help='開始日（YYYY-MM-DD）')
+    parser.add_argument('--end-date', type=str, help='終了日（YYYY-MM-DD）')
+    parser.add_argument('--interval-min', type=int, default=5, help='リサンプル間隔（分）')
+    parser.add_argument('--raw', action='store_true',
+                         help='生ログのcode一覧を表示して終了（CSVは書かない）')
+    args = parser.parse_args()
+
+    creds = load_creds()
+
+    start, end = resolve_period(args)
+    print(f"室内環境データ取得: {start} ～ {end}")
+
+    try:
+        cloud = tuya_client.create_cloud(creds)
+        logs = tuya_client.fetch_device_log(cloud, creds['device_id'], start, end)
+
+        if args.raw:
+            print(tuya_client.summarize_raw_logs(logs))
+            if not logs:
+                sys.exit(1)
+            return 0
+
+        if not logs:
+            print(f"⚠️ 期間 {start}〜{end} のログが0件。"
+                  "デバイスがオフラインか、取得が壊れている可能性がある")
+            sys.exit(1)
+
+        scales = tuya_client.resolve_scales(cloud, creds['device_id'])
+        df_new = tuya_client.logs_to_dataframe(logs, scales=scales,
+                                                interval_min=args.interval_min)
+
+        if df_new.empty:
+            print(f"⚠️ 期間 {start}〜{end} のログから有効なデータを抽出できなかった"
+                  "（DP_CODE_MAPが実機のcodeと一致していない可能性がある。--raw で確認すること）")
+            sys.exit(1)
+
+        df_merged = csv_utils.merge_csv_by_columns(
+            df_new, CSV_FILE, key_columns=['datetime'], sort_by=['datetime'],
+        )
+
+        CSV_FILE.parent.mkdir(parents=True, exist_ok=True)
+        df_merged.to_csv(CSV_FILE, index=False)
+
+        period_min = df_merged['datetime'].min()
+        period_max = df_merged['datetime'].max()
+        print(f"取得件数: {len(df_new)}行（リサンプル後）")
+        print(f"保存完了: {CSV_FILE} (総行数 {len(df_merged)}行)")
+        print(f"CSVの期間: {period_min} ～ {period_max}")
+        return 0
+
+    except TuyaCloudError as e:
+        print(f"⚠️ Tuya Cloud APIエラー: {e}")
+        print("Tuya IoT Platform の Trial アカウントの有効期限切れの可能性がある。"
+              "管理画面から延長申請を確認すること。")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/lib/clients/tuya_client.py
+++ b/src/lib/clients/tuya_client.py
@@ -1,0 +1,294 @@
+"""Tuya Cloud API クライアント（CO2モニター向け）
+
+LSENLTY WiFi CO2モニター（Tuya/Smart Life系デバイス）から、Tuya Cloud API 経由で
+過去のデバイスログ（CO2・温度・湿度）を取得する。LAN ローカル接続（tinytuya.Device）は
+未対応。Device Log Service は無料枠で過去7日分しか保持しない恒久的な仕様（Trialの制限ではない。
+それ以上遡るには年額USD 1,500〜の有料プランが必要）のため、日次バッチでの差分蓄積が必須となる。
+
+これとは別に、Cloud Project 自体の Trial アカウントは1ヶ月で期限切れし、これも API エラーの
+要因になりうる（両者は無関係な別の制限）。
+"""
+
+import datetime as dt
+import json
+import logging
+
+import pandas as pd
+import tinytuya
+
+logger = logging.getLogger(__name__)
+
+JST = dt.timezone(dt.timedelta(hours=9))
+
+# Tuya の DP コード → CSV 列名 とフォールバックのスケール（値をこの数で割る）。
+# コードもスケールも機種依存。実機で確定させるには `--raw` を使うこと。
+# 複数エイリアスを持たせているのは機種差をある程度吸収する意図。実機未確認のため暫定。
+DP_CODE_MAP = {
+    'co2_value':      {'column': 'co2_ppm',     'scale': 1},
+    'co2':            {'column': 'co2_ppm',     'scale': 1},
+    'temp_current':   {'column': 'temperature', 'scale': 10},
+    'va_temperature': {'column': 'temperature', 'scale': 10},
+    'humidity_value':  {'column': 'humidity',    'scale': 1},
+    'va_humidity':     {'column': 'humidity',    'scale': 1},
+}
+
+CSV_COLUMNS = ['co2_ppm', 'temperature', 'humidity']
+
+# Device Log Service の無料枠が保持する最大日数（恒久的な仕様。Trial期限切れとは別問題）
+CLOUD_LOG_MAX_DAYS = 7
+
+
+class TuyaCloudError(Exception):
+    """Tuya Cloud API がエラーを返した場合の例外"""
+
+
+def _check_error(result):
+    """tinytuya の Cloud API レスポンスをエラーチェックする
+
+    tinytuya の Cloud API は失敗時に例外を投げず
+    ``{'Error': ..., 'Err': ..., 'Payload': ...}`` の形で返す。
+    すべての API 呼び出しの戻り値をこれに通すこと。
+
+    Parameters
+    ----------
+    result : dict
+        tinytuya.Cloud の各メソッドの戻り値
+
+    Returns
+    -------
+    dict
+        result をそのまま返す（チェーン用）
+
+    Raises
+    ------
+    TuyaCloudError
+        result がエラーを表す場合
+    """
+    if isinstance(result, dict) and 'Error' in result:
+        err = result.get('Err')
+        msg = result.get('Error')
+        raise TuyaCloudError(f"Tuya Cloud API エラー (Err={err}): {msg}")
+    return result
+
+
+def create_cloud(creds: dict) -> tinytuya.Cloud:
+    """認証情報から tinytuya.Cloud インスタンスを作成する
+
+    Parameters
+    ----------
+    creds : dict
+        api_region / api_key / api_secret / device_id を持つ辞書
+
+    Returns
+    -------
+    tinytuya.Cloud
+    """
+    return tinytuya.Cloud(
+        apiRegion=creds['api_region'],
+        apiKey=creds['api_key'],
+        apiSecret=creds['api_secret'],
+        apiDeviceID=creds['device_id'],
+    )
+
+
+def resolve_scales(cloud: tinytuya.Cloud, device_id: str) -> dict[str, float]:
+    """デバイスの spec からコードごとのスケール除数を取得する
+
+    Tuya の spec では `values` フィールドが JSON 文字列で入っており、その中に
+    ``"scale": 1`` のような整数が入っている。scale は10の冪指数で、
+    実値 = 生値 / 10**scale となる。
+
+    getproperties のレスポンス構造は機種・APIバージョンで揺れるため、
+    パースに失敗しても例外を投げず空 dict を返す（フォールバックは呼び出し側の
+    DP_CODE_MAP に委ねる）。プロパティが取れなくてもログ取得自体は続行できるため、
+    ここだけは _check_error で落とさず warning ログに留める。
+
+    Parameters
+    ----------
+    cloud : tinytuya.Cloud
+    device_id : str
+
+    Returns
+    -------
+    dict[str, float]
+        {code: 除数}。取得・パース失敗時は空 dict
+    """
+    try:
+        result = cloud.getproperties(device_id)
+    except Exception as e:
+        logger.warning("getproperties の呼び出しに失敗: %s", e)
+        return {}
+
+    if isinstance(result, dict) and 'Error' in result:
+        logger.warning("getproperties がエラーを返した: %s", result.get('Error'))
+        return {}
+
+    scales: dict[str, float] = {}
+    try:
+        status = result.get('result', {}).get('status', [])
+        for prop in status:
+            code = prop.get('code')
+            values_raw = prop.get('values')
+            if not code or not values_raw:
+                continue
+            values = json.loads(values_raw) if isinstance(values_raw, str) else values_raw
+            scale = values.get('scale') if isinstance(values, dict) else None
+            if scale is not None:
+                scales[code] = float(10 ** int(scale))
+    except Exception as e:
+        logger.warning("getproperties のパースに失敗: %s", e)
+        return {}
+
+    return scales
+
+
+def _jst_date_to_epoch(d: dt.date, end_of_day: bool = False) -> int:
+    """JST の日付境界を unix epoch 秒に変換する"""
+    if end_of_day:
+        t = dt.time(23, 59, 59)
+    else:
+        t = dt.time(0, 0, 0)
+    ts = dt.datetime.combine(d, t, tzinfo=JST)
+    return int(ts.timestamp())
+
+
+def fetch_device_log(cloud: tinytuya.Cloud, device_id: str,
+                      start: dt.date, end: dt.date) -> list[dict]:
+    """指定期間のデバイスログ（event type 7 = data report）を取得する
+
+    Cloud API は最大1週間しか遡れない。要求期間が7日を超える場合は
+    warning を出す（エラーにはしない）。
+
+    Parameters
+    ----------
+    cloud : tinytuya.Cloud
+    device_id : str
+    start, end : datetime.date
+        取得期間（両端を含む）。JST の日付境界で epoch 秒に変換して渡す
+
+    Returns
+    -------
+    list[dict]
+        ログエントリのリスト（各要素は event_time(ms) / code / value 等を持つ）
+    """
+    if (end - start).days + 1 > CLOUD_LOG_MAX_DAYS:
+        logger.warning(
+            "要求期間が%d日を超えている（%s ～ %s）。Tuya Cloud APIは最大%d日分しか遡れない",
+            CLOUD_LOG_MAX_DAYS, start, end, CLOUD_LOG_MAX_DAYS,
+        )
+
+    start_epoch = _jst_date_to_epoch(start, end_of_day=False)
+    end_epoch = _jst_date_to_epoch(end, end_of_day=True)
+
+    result = cloud.getdevicelog(device_id, start=start_epoch, end=end_epoch,
+                                 evtype='7', size=0)
+    _check_error(result)
+
+    return result.get('result', {}).get('logs', [])
+
+
+def logs_to_dataframe(logs: list[dict], scales: dict[str, float] | None = None,
+                       interval_min: int = 5) -> pd.DataFrame:
+    """デバイスログを CSV 用 DataFrame に変換する
+
+    Parameters
+    ----------
+    logs : list[dict]
+        fetch_device_log() が返すログエントリのリスト
+    scales : dict[str, float] | None
+        resolve_scales() が返すコードごとの除数。該当コードが無ければ
+        DP_CODE_MAP のフォールバック値を使う
+    interval_min : int
+        resample する間隔（分）
+
+    Returns
+    -------
+    pd.DataFrame
+        列 ['datetime', 'co2_ppm', 'temperature', 'humidity']。
+        datetime は JST tz-naive の '%Y-%m-%d %H:%M:%S' 文字列
+    """
+    scales = scales or {}
+    out_columns = ['datetime'] + CSV_COLUMNS
+
+    if not logs:
+        return pd.DataFrame(columns=out_columns)
+
+    rows = []
+    for log in logs:
+        code = log.get('code')
+        mapping = DP_CODE_MAP.get(code)
+        if mapping is None:
+            continue
+
+        try:
+            value = float(log.get('value'))
+        except (TypeError, ValueError):
+            continue
+
+        event_time_ms = log.get('event_time')
+        if event_time_ms is None:
+            continue
+        ts = pd.Timestamp(int(event_time_ms), unit='ms', tz='UTC').tz_convert(JST).tz_localize(None)
+
+        divisor = scales.get(code, mapping['scale'])
+        rows.append({
+            'datetime': ts,
+            'column': mapping['column'],
+            'value': value / divisor,
+        })
+
+    if not rows:
+        return pd.DataFrame(columns=out_columns)
+
+    df = pd.DataFrame(rows)
+    # 同一タイムスタンプ・同一列の重複は平均でよい
+    pivoted = df.pivot_table(index='datetime', columns='column', values='value', aggfunc='mean')
+
+    resampled = pivoted.resample(f'{interval_min}min').mean()
+    # 全列が NaN の行は落とす（デバイスが offline の時間帯に空行を作らない）
+    resampled = resampled.dropna(how='all')
+
+    for col in CSV_COLUMNS:
+        if col not in resampled.columns:
+            resampled[col] = pd.NA
+    resampled = resampled[CSV_COLUMNS]
+    resampled.columns.name = None
+
+    resampled = resampled.reset_index()
+    resampled['datetime'] = resampled['datetime'].dt.strftime('%Y-%m-%d %H:%M:%S')
+
+    return resampled[out_columns]
+
+
+def summarize_raw_logs(logs: list[dict]) -> str:
+    """生ログを DP コード同定用に人間可読な文字列にまとめる（--raw 用）
+
+    Parameters
+    ----------
+    logs : list[dict]
+        fetch_device_log() が返すログエントリのリスト
+
+    Returns
+    -------
+    str
+        code ごとの出現件数・値のサンプル・DP_CODE_MAP に載っているかをまとめたテキスト
+    """
+    if not logs:
+        return "ログが0件です。"
+
+    by_code: dict[str, list] = {}
+    for log in logs:
+        code = log.get('code', '(unknown)')
+        by_code.setdefault(code, []).append(log.get('value'))
+
+    lines = [f"検出された code: {len(by_code)}種類 / ログ総数: {len(logs)}件", '']
+    for code, values in sorted(by_code.items()):
+        known = code in DP_CODE_MAP
+        mapping_info = (
+            f"→ column={DP_CODE_MAP[code]['column']}, fallback_scale={DP_CODE_MAP[code]['scale']}"
+            if known else "→ DP_CODE_MAP未登録"
+        )
+        samples = values[:3]
+        lines.append(f"- {code}: {len(values)}件 サンプル={samples} {mapping_info}")
+
+    return '\n'.join(lines)

--- a/uv.lock
+++ b/uv.lock
@@ -77,6 +77,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -163,6 +172,7 @@ dependencies = [
     { name = "requests-oauthlib" },
     { name = "scipy" },
     { name = "tabulate" },
+    { name = "tinytuya" },
 ]
 
 [package.metadata]
@@ -179,6 +189,7 @@ requires-dist = [
     { name = "requests-oauthlib" },
     { name = "scipy", specifier = ">=1.17.1" },
     { name = "tabulate", specifier = ">=0.10.0" },
+    { name = "tinytuya", specifier = ">=1.20.0" },
 ]
 
 [[package]]
@@ -657,6 +668,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]
+
+[[package]]
+name = "tinytuya"
+version = "1.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+    { name = "cryptography" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/ba/4199064373d6aa310e32e69b2c397937b4c25f5f8862a514ecdaeb34fe36/tinytuya-1.20.0.tar.gz", hash = "sha256:54bfcd0b3411ae4c94cf473e1ca28a2ffa4d376ed2d8e7e4e4adfcdf4ca1657c", size = 190632, upload-time = "2026-07-06T04:39:14.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/87/3b1ac3cae266e82bf40cbc5cccb7a80e0c28b9a0b65a4ad9b088e190d507/tinytuya-1.20.0-py3-none-any.whl", hash = "sha256:ac5650c30f1153b1eae0b8d75f67043fb2397a168d3834e47da2d88d2c08c722", size = 170518, upload-time = "2026-07-06T04:39:12.997Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要

Issue #42 の実装。LSENLTY WiFi CO2モニター（Tuya系デバイス）から Tuya Cloud API 経由で CO2/温度/湿度を取得し、`data/environment.csv` に日次バッチで蓄積するスクリプトを追加する。

既存の `scripts/fetch_toggl.py` + `src/lib/clients/toggl_client.py` の二層構成（スクリプト = CLI/CSV永続化、クライアント = API通信/変換）を踏襲した。

## 変更内容

- `pyproject.toml` / `uv.lock` — `tinytuya` を依存に追加（`uv add` で更新）
- `config/tuya_creds.json.sample`（新規） — 認証情報サンプル
- `src/lib/clients/tuya_client.py`（新規） — Tuya Cloud API クライアント
  - `DP_CODE_MAP`: DPコード→CSV列名・フォールバックスケールの対応表（実機未確認のため暫定。複数エイリアスで機種差を吸収する意図）
  - `_check_error()`: tinytuya Cloud APIの `{'Error': ...}` 形式のレスポンスを例外化する沈黙故障対策
  - `resolve_scales()`: `getproperties()` から実機のスケールを取得。パース失敗時は空dictを返しフォールバックに委ねる
  - `fetch_device_log()`: `getdevicelog(evtype='7')` で過去ログ取得。7日を超える要求はwarning
  - `logs_to_dataframe()`: ログをCSV用DataFrameに変換（pivot→resample→NaN行除去）
  - `summarize_raw_logs()`: `--raw` 用、DPコード同定支援
- `scripts/fetch_environment.py`（新規） — 取得スクリプト（`--days` / `--start-date` / `--end-date` / `--interval-min` / `--raw`）
  - creds未配置時・APIエラー時・取得0件時に非0終了
  - APIエラー時は「Trial期限切れの可能性」を案内文言に含める（Cloud Project自体のTrial期限とDevice Log Serviceの7日保持は別問題として明確に区別）
- `CLAUDE.md` — Running Scripts / Project Structure / Configuration セクションに追記

## スコープ外（Issue通り）

- LANローカル接続（`tinytuya.Device`）
- レポート生成側での `environment.csv` 利用
- `scripts/fetch_all.sh` への追加（実機未到着で毎回失敗するため）
- `data/environment.csv` 自体のコミット（実機が無く生成されない）

## Test plan

実機・Tuya Cloud認証情報が無いため、実API疎通確認はできていない。以下のみ確認した:

- [x] `uv run scripts/fetch_environment.py --help` が通ること（実行して出力確認済み）
- [x] `config/tuya_creds.json` が無い状態で `uv run scripts/fetch_environment.py --days 7` を実行し、セットアップ手順の案内が出て exit code が非0であること（`echo $?` で1を確認済み）
- [x] `logs_to_dataframe()` にダミーのログJSON（`co2_value`/`temp_current`/`humidity_value`/未登録code混在）を食わせ、期待通りのDataFrame（列順・resample・スケール適用・未登録code除外・空リスト時の空DataFrame）が出ることを確認済み（scratchpadの使い捨てスクリプトで実行、リポジトリにはコミットしていない）
- [x] `uv run python <script>` で `tuya_client` の import が実際に通ることを確認済み（上記確認と同時に実施）

**未確認（実機・実APIが無いため）:**
- Tuya Cloud APIへの実疎通（認証・`getdevicelog`・`getproperties`）
- `DP_CODE_MAP` のDPコード名の正しさ（実機のcodeと一致するか）
- スケール値（temperature ×10 等）の正しさ
- 2回実行時のCSVマージでの重複排除の実動作（実データが無いため）

---
🤖 Claude Code session: `103b8140-0f49-4b39-ab67-0b60ef495ded`